### PR TITLE
Vendredi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-.DS_Store
-.basex
-.basexgui
-webapp/dba/
-webapp/perso/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .basex
 .basexgui
 webapp/dba/
+webapp/perso/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .basex
 .basexgui
+webapp/dba/

--- a/data/.logs/2014-11-06.log
+++ b/data/.logs/2014-11-06.log
@@ -1,8 +1,0 @@
-10:30:48.767	SERVER	admin	OK	Server was started (port: 1984)
-10:30:48.782	SERVER	admin	OK	HTTP Server was started (port: 8984)
-10:30:53.512	0:0:0:0:0:0:0:1:51688	admin	REQUEST	[GET] http://localhost:8984/tei?status=1
-10:30:53.807	0:0:0:0:0:0:0:1:51688	admin	400	Stopped at /home/mingarao/Documents/git/synopsx-ahn/repo/synopsx/models/tei.xqm, 17/12: [bxerr:BXDB0002] Database 'hyperdonat' was not found.	296.75 ms
-10:32:35.209	0:0:0:0:0:0:0:1:51691	admin	REQUEST	[GET] http://localhost:8984/rest
-10:32:35.234	0:0:0:0:0:0:0:1:51691	admin	200		24.97 ms
-10:40:08.301	SERVER	admin	OK	HTTP Server was stopped (port: 8984)
-10:40:08.302	SERVER	admin	OK	Server was stopped (port: 1984)

--- a/webapp/static/xsl/biblio.xsl
+++ b/webapp/static/xsl/biblio.xsl
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.1" exclude-result-prefixes="tei"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns="http://www.w3.org/1999/xhtml">
+    
+    <xsl:output indent="yes" method="xml" encoding="UTF-8" omit-xml-declaration="yes" />
+    
+    <xsl:strip-space elements="*" />
+    
+    <!-- ci-dessous à remplacer pour l'intégration -->
+    <xsl:template match="/">
+        <xsl:apply-templates />
+    </xsl:template>
+    
+    <xsl:template match="tei:teiHeader | tei:head" />
+
+        
+    <xsl:template match="tei:biblStruct" >
+        <div class="ref_bibl" id="{@xml:id}">
+            <xsl:apply-templates select="tei:analytic" />
+            <xsl:apply-templates select="tei:monogr" />
+            <xsl:text>.</xsl:text>
+            <xsl:apply-templates select="tei:series" />
+            <!-- afficher extent si présent -->
+            <xsl:if test="tei:monogr/tei:extent">
+                <xsl:value-of
+                    select="tei:monogr/tei:extent" />
+            </xsl:if>
+            <!-- instanciation des identifiants -->
+            <xsl:apply-templates select="tei:idno[@type='isbn10']" />
+            <xsl:apply-templates select="tei:idno[@type='catBnf']" />
+        </div>
+    </xsl:template>
+    
+    
+    <!-- traitement de analytic -->
+    <xsl:template match="tei:analytic" >
+        <xsl:apply-templates select="tei:author | tei:editor" />
+        <xsl:apply-templates select="tei:title" />
+        <xsl:choose>
+            <xsl:when test="following-sibling::tei:monogr/tei:title[@level='m']" >
+                <xsl:text>. In </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>. </xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- traitement de monogr-->
+    <xsl:template match="tei:monogr" >
+        <xsl:choose>
+            <!-- lorsque suit un analytic -->
+            <xsl:when test="preceding-sibling::tei:analytic and preceding-sibling::tei:title[@level='a']">
+                <xsl:apply-templates select="tei:author | tei:editor"  />
+                <xsl:apply-templates select="tei:title"  />
+                <xsl:if test="tei:edition">
+                    <xsl:text>, </xsl:text>
+                    <xsl:apply-templates select="tei:edition" />
+                </xsl:if>
+                <xsl:if test="tei:meeting">
+                    <xsl:text>, </xsl:text>
+                    <xsl:apply-templates select="tei:meeting" />
+                </xsl:if>
+                <xsl:text>, </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="tei:author | tei:editor" />
+                <xsl:apply-templates select="tei:title" />
+                <xsl:if test="tei:edition">
+                    <xsl:text>. </xsl:text>
+                    <xsl:apply-templates select="tei:edition"  />
+                </xsl:if>
+                <xsl:if test="tei:meeting">
+                    <xsl:text>. </xsl:text>
+                    <xsl:apply-templates select="tei:meeting"  />
+                </xsl:if>
+                <xsl:text>. </xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:choose>
+            <xsl:when test="ancestor-or-self::tei:biblStruct/*/tei:title/@level='u'">
+                <xsl:value-of select="tei:imprint"/>
+            </xsl:when>
+            <xsl:when test="tei:title/@level='m'">
+                <xsl:apply-templates select="tei:imprint" mode="monographie"/>
+            </xsl:when>
+            <xsl:when test="tei:title/@level='j'">
+                <xsl:apply-templates select="tei:imprint" mode="journal" />
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="tei:series" >
+        <xsl:text>(</xsl:text>
+        <xsl:value-of select="tei:title"/>
+        <xsl:if test="tei:biblScope">
+            <xsl:text>, n°&#160;</xsl:text>
+            <xsl:value-of select="."/>
+        </xsl:if>
+        <xsl:text>)</xsl:text>
+    </xsl:template>
+    
+    <!-- mentions de responsabilités -->
+    <xsl:template match="tei:editor | tei:author" >
+        <span class="persName">
+            <xsl:for-each select="tei:persName">
+                <xsl:apply-templates select="."  />
+                <xsl:if test="parent::tei:editor and position() = last()">
+                    <xsl:choose>
+                        <xsl:when test="position() &gt;2">
+                            <xsl:text>, (éds.) </xsl:text>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:text>, (éd.) </xsl:text>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:if>
+            </xsl:for-each>
+            <xsl:text>.</xsl:text>
+        </span>
+        <xsl:text> </xsl:text>
+    </xsl:template>
+    
+    <xsl:template match="tei:persName" >
+        <xsl:value-of select="normalize-space(tei:forename)" />
+        <xsl:text> </xsl:text>
+        <span class="surname">
+            <xsl:value-of select="normalize-space(tei:surname)" />
+        </span>
+        <xsl:if
+            test="following-sibling::tei:persName | following-sibling::tei:editor">
+            <xsl:text>, </xsl:text>
+        </xsl:if>
+    </xsl:template>
+    
+    <!-- traitement des titres -->
+    <xsl:template match="tei:title" >
+        <em class="title">
+            <xsl:value-of select="normalize-space(.)" />
+        </em>
+    </xsl:template>
+    
+    <xsl:template match="tei:title[@level='a']" >
+        <span class="title">
+            <xsl:text>« </xsl:text>
+            <xsl:value-of select="normalize-space(.)" />
+            <xsl:text> »</xsl:text>
+        </span>
+    </xsl:template>
+    
+    <!-- mentions d'édition -->
+    <xsl:template match="tei:edition" >
+        <span class="edition">
+            <xsl:value-of select="normalize-space(.)"/>
+        </span>
+    </xsl:template>
+    <xsl:template match="tei:meeting" >
+        <span class="meeting">
+            <xsl:value-of select="normalize-space(.)"/>
+        </span>
+    </xsl:template>
+    
+    <xsl:template match="tei:imprint" mode="monographie">
+        <span class="imprint">
+            <xsl:if test="tei:biblScope/@type='vol'">
+                <xsl:value-of select="tei:biblScope[@type='vol']" /> vol. </xsl:if>
+            <xsl:choose>
+                <xsl:when test="tei:pubPlace">
+                    <xsl:value-of select="tei:pubPlace" />
+                    <xsl:text>&#160;: </xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>s.l.&#160;: </xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="tei:publisher" >
+                    <xsl:value-of select="tei:publisher" />
+                    <xsl:text>, </xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>s.p., </xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="tei:date">
+                    <xsl:value-of select="tei:date" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>s.d</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </span>
+    </xsl:template>
+    
+    <xsl:template match="tei:imprint" mode="journal">
+        <span class="imprint">
+            <xsl:if test="tei:biblScope/@type='vol'">
+                <xsl:text>Vol.&#160;:</xsl:text>
+                <xsl:value-of select="tei:imprint/tei:biblScope[@type='vol']" />
+                <xsl:text>, </xsl:text>
+            </xsl:if>
+            <xsl:if test="tei:biblScope/@type='no'">
+                <xsl:text>n°&#160;</xsl:text>
+                <xsl:value-of select="tei:biblScope[@type='no']" />
+                <xsl:text>, </xsl:text>
+            </xsl:if>
+            <xsl:if test="tei:date">
+                <xsl:text>&#160;</xsl:text>
+                <xsl:value-of select="tei:date" />
+                <xsl:text>, </xsl:text>
+            </xsl:if>
+            <xsl:if test="tei:biblScope/@type='pp'">
+                <xsl:text>p.&#160;</xsl:text>
+                <xsl:value-of select="tei:biblScope[@type='pp']" />
+            </xsl:if>
+        </span>
+    </xsl:template>
+    
+    <!-- traitement des identifiants -->
+    <xsl:template match="tei:idno[@type='catBnf']" >
+        <div class="bnf">
+            <a target="_blank">
+                <xsl:attribute name="href">
+                    <xsl:value-of select="."/>
+                </xsl:attribute>
+                <xsl:text>Bnf</xsl:text>
+            </a>
+        </div>
+    </xsl:template>
+    
+    <xsl:template match="tei:idno[@type='isbn10']" >
+        <div>
+            <xsl:text>ISBN </xsl:text>
+            <xsl:apply-templates/>
+        </div>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/webapp/static/xsl/biblioRevisee.xsl
+++ b/webapp/static/xsl/biblioRevisee.xsl
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.1" exclude-result-prefixes="tei"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    xmlns="http://www.w3.org/1999/xhtml">
+    
+    <xsl:output indent="yes" method="xml" encoding="UTF-8"
+        doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" />
+    
+    <xsl:strip-space elements="*" />
+    
+    <!-- ci-dessous à remplacer pour l'intégration -->
+    <xsl:template match="/">
+        <html>
+            <head></head>
+            <body>
+                <div>
+                    <xsl:apply-templates />
+                </div>
+            </body>
+        </html>
+    </xsl:template>
+    
+    <!-- instanciation de la règle -->
+    <xsl:template match="tei:listBibl">
+        <div class="listBibl">
+            <xsl:for-each select="tei:biblStruct">
+                <!-- TODO : introduire un sort ? -->
+                <xsl:call-template name="biblStruct"/>
+            </xsl:for-each>
+        </div>
+    </xsl:template>
+
+    <!-- traiteemnt des éléments biblStruct -->
+    <xsl:template name="biblStruct" mode="bibl">
+        <div class="biblStruct" id="{@xml:id}">
+<!-- ajout pauline id -->
+<xsl:if test="descendant-or-self::tei:idno[@type='catBnf' or @type='isbn10' or @type='isbn13' or @type='doi']">
+                <div class="right-column">
+                    <xsl:for-each select="descendant-or-self::tei:idno[@type='catBnf']">
+                        <div class="bnf">
+                            <a target="_blank">
+                                <xsl:attribute name="href">
+                                    <xsl:apply-templates/>
+                                </xsl:attribute>
+                                <xsl:attribute name="title">
+                                    <xsl:text>Accéder à la fiche du catalogue de la BNF</xsl:text>
+                                </xsl:attribute>
+                                <xsl:text>Bnf</xsl:text>
+                            </a>
+                        </div>
+                    </xsl:for-each>
+                    <xsl:for-each select="descendant-or-self::tei:idno[@type='isbn10' or @type='isbn13' or @type='doi']">
+                        <div class="isbn">
+                            <a target="_blank">
+                                <xsl:choose>
+                                    <xsl:when test="@type='isbn10'">
+                                        <xsl:attribute name="href">
+                                            <xsl:text>http://www.worldcat.org/search?q=bn%3A</xsl:text>
+                                            <xsl:apply-templates/>
+                                        </xsl:attribute>
+                                        <xsl:if test="@type='isbn10'">
+                                            <xsl:text>ISBN-10&#160;:&#160;</xsl:text>
+                                        </xsl:if>
+                                        <xsl:apply-templates/>
+                                    </xsl:when>
+                                    <xsl:when test="@type='isbn13'">
+                                        <xsl:attribute name="href">
+                                            <xsl:text>http://www.worldcat.org/search?q=bn%3A</xsl:text>
+                                            <xsl:apply-templates/>
+                                        </xsl:attribute>
+                                        <xsl:if test="@type='isbn13'">
+                                            <xsl:text>ISBN-13&#160;:&#160;</xsl:text>
+                                        </xsl:if>
+                                        <xsl:apply-templates/>
+                                    </xsl:when>
+                                    <xsl:when test="@type='doi'">
+                                        <xsl:attribute name="href">
+                                            <xsl:text>http://dx.doi.org/</xsl:text>
+                                            <xsl:apply-templates/>
+                                        </xsl:attribute>
+                                        <xsl:text>DOI</xsl:text>
+                                    </xsl:when>
+                                    <xsl:otherwise/>
+                                </xsl:choose>
+                            </a>
+                        </div>
+                    </xsl:for-each>
+                    
+                </div>
+            </xsl:if>
+<!-- fin ajout Pauline -->
+            <xsl:apply-templates select="tei:analytic" mode="bibl"/>
+            <xsl:apply-templates select="tei:monogr" mode="bibl"/>
+            <xsl:text>.</xsl:text>
+            <xsl:apply-templates select="tei:series" mode="bibl"/>
+            <!-- afficher extent si présent -->
+            <xsl:if test="tei:monogr/tei:extent">
+                <xsl:value-of
+                    select="tei:monogr/tei:extent" />
+            </xsl:if>
+            <!-- instanciation des identifiants -->
+            <xsl:apply-templates select="tei:idno[@type]" mode="bibl"/>
+        </div>
+    </xsl:template>
+    
+    
+    <!-- traitement de analytic -->
+    <xsl:template match="tei:analytic" mode="bibl">
+        <xsl:apply-templates select="tei:author | tei:editor" mode="bibl"/>
+        <xsl:apply-templates select="tei:title" mode="bibl"/>
+        <xsl:choose>
+            <xsl:when test="following-sibling::tei:monogr/tei:title[@level='m']" >
+                <xsl:text>. In </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text>. </xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <!-- traitement de monogr-->
+    <xsl:template match="tei:monogr" mode="bibl">
+        <xsl:choose>
+            <!-- lorsque suit un analytic -->
+            <xsl:when test="preceding-sibling::tei:analytic and preceding-sibling::tei:title[@level='a']">
+                <xsl:apply-templates select="tei:author | tei:editor" mode="bibl" />
+                <xsl:apply-templates select="tei:title" mode="bibl" />
+                <xsl:if test="tei:edition">
+                    <xsl:text>, </xsl:text>
+                    <xsl:apply-templates select="tei:edition" mode="bibl"/>
+                </xsl:if>
+                <xsl:if test="tei:meeting">
+                    <xsl:text>, </xsl:text>
+                    <xsl:apply-templates select="tei:meeting" mode="bibl"/>
+                </xsl:if>
+                <xsl:text>, </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="tei:author | tei:editor" mode="bibl"/>
+                <xsl:apply-templates select="tei:title" mode="bibl"/>
+                <xsl:if test="tei:edition">
+                    <xsl:text>. </xsl:text>
+                    <xsl:apply-templates select="tei:edition" mode="bibl" />
+                </xsl:if>
+                <xsl:if test="tei:meeting">
+                    <xsl:text>. </xsl:text>
+                    <xsl:apply-templates select="tei:meeting" mode="bibl" />
+                </xsl:if>
+                <xsl:text>. </xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:choose>
+            <xsl:when test="ancestor-or-self::tei:biblStruct/*/tei:title/@level='u'">
+                <xsl:value-of select="tei:imprint"/>
+            </xsl:when>
+            <xsl:when test="tei:title/@level='m'">
+                <xsl:apply-templates select="tei:imprint" mode="monographie"/>
+            </xsl:when>
+            <xsl:when test="tei:title/@level='j'">
+                <xsl:apply-templates select="tei:imprint" mode="journal" />
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="tei:series" mode="bibl">
+        <xsl:text>(</xsl:text>
+        <xsl:value-of select="tei:title"/>
+        <xsl:if test="tei:biblScope">
+            <xsl:text>, n°&#160;</xsl:text>
+            <xsl:value-of select=".[@type='issue']"/>
+        </xsl:if>
+        <xsl:text>)</xsl:text>
+    </xsl:template>
+    
+    <!-- mentions de responsabilités -->
+    <xsl:template match="tei:editor | tei:author | tei:respStmt" mode="bibl">
+        <span class="persName">
+            <xsl:for-each select="tei:persName">
+<xsl:if test="position()&lt;4">
+                <xsl:apply-templates select="." mode="bibl" />
+<xsl:if
+                        test="following-sibling::tei:persName | following-sibling::tei:editor | following-sibling::tei:respStmt">
+                        <xsl:text>, </xsl:text>
+                    </xsl:if>
+                </xsl:if>
+<xsl:if test="position()=3 and not(position() = last())">
+                    <em><xsl:text>, et al.</xsl:text></em>
+                </xsl:if>
+                <xsl:if test="parent::tei:editor and position() = last()">
+                    <xsl:choose>
+                        <xsl:when test="position() &gt;2">
+                            <xsl:text>, (éds.) </xsl:text>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:text>, (éd.) </xsl:text>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:if>
+            </xsl:for-each>
+            <xsl:for-each select="tei:orgName">
+                <xsl:apply-templates/>
+            </xsl:for-each>
+            
+            <xsl:if test="tei:resp">
+                <xsl:text> (</xsl:text>
+                <xsl:value-of select="tei:resp"/>
+                <xsl:text>)</xsl:text>
+            </xsl:if>
+            <xsl:if test="ancestor::tei:msDesc">
+                 <xsl:text>, </xsl:text>
+            </xsl:if>
+            <xsl:if test="ancestor::tei:biblStruct">
+                <xsl:text>.</xsl:text>
+            </xsl:if>
+        </span>
+        <xsl:text> </xsl:text>
+    </xsl:template>
+    
+    <xsl:template match="tei:persName" mode="bibl">
+        <xsl:value-of select="normalize-space(tei:forename)" />
+        <xsl:text> </xsl:text>
+        <span class="surname">
+            <xsl:value-of select="normalize-space(tei:surname)" />
+        </span>
+        <xsl:if
+            test="following-sibling::tei:persName | following-sibling::tei:editor">
+            <xsl:text>, </xsl:text>
+        </xsl:if>
+    </xsl:template>
+    
+    <!-- traitement des titres -->
+    <xsl:template match="tei:title" mode="bibl">
+        <em class="title">
+            <!-- <xsl:value-of select="normalize-space(.)" />-->
+<xsl:apply-templates/>
+        </em>
+    </xsl:template>
+    
+    <xsl:template match="tei:title[@level='a']" mode="bibl">
+        <span class="title">
+            <xsl:text>« </xsl:text>
+            <!-- <xsl:value-of select="normalize-space(.)" />-->
+<xsl:apply-templates/>
+            <xsl:text> »</xsl:text>
+        </span>
+    </xsl:template>
+    
+    <!-- mentions d'édition -->
+    <xsl:template match="tei:edition" mode="bibl">
+        <span class="edition">
+            <!-- <xsl:value-of select="normalize-space(.)" />-->
+<xsl:apply-templates/>
+        </span>
+    </xsl:template>
+    <xsl:template match="tei:meeting" mode="bibl">
+        <span class="meeting">
+            <!-- <xsl:value-of select="normalize-space(.)" />-->
+<xsl:apply-templates/>
+        </span>
+    </xsl:template>
+    
+    <xsl:template match="tei:imprint" mode="monographie">
+        <span class="imprint">
+            <xsl:if test="tei:biblScope/@type='vol'">
+                <xsl:value-of select="tei:biblScope[@type='vol']" /> vol. </xsl:if>
+            <xsl:choose>
+                <xsl:when test="tei:pubPlace">
+                    <xsl:value-of select="tei:pubPlace" />
+                    <xsl:text>&#160;: </xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>s.l.&#160;: </xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="tei:publisher" >
+                    <xsl:value-of select="tei:publisher" />
+                    <xsl:text>, </xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>s.p., </xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:choose>
+                <xsl:when test="tei:date">
+                    <xsl:value-of select="tei:date" />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>s.d</xsl:text>
+                </xsl:otherwise>
+            </xsl:choose>
+        </span>
+    </xsl:template>
+    
+    <xsl:template match="tei:imprint" mode="journal">
+        <span class="imprint">
+            <xsl:if test="tei:biblScope/@type='vol'">
+                <xsl:text>Vol.&#160;:</xsl:text>
+                <xsl:value-of select="tei:imprint/tei:biblScope[@type='vol']" />
+                <xsl:text>, </xsl:text>
+            </xsl:if>
+            <xsl:if test="tei:biblScope/@type='no'">
+                <xsl:text>n°&#160;</xsl:text>
+                <xsl:value-of select="tei:biblScope[@type='no']" />
+                <xsl:text>, </xsl:text>
+            </xsl:if>
+            <xsl:if test="tei:date">
+                <xsl:text>&#160;</xsl:text>
+                <xsl:value-of select="tei:date" />
+                <xsl:text>, </xsl:text>
+            </xsl:if>
+            <xsl:if test="tei:biblScope/@type='pp'">
+                <xsl:text>p.&#160;</xsl:text>
+                <xsl:value-of select="tei:biblScope[@type='pp']" />
+            </xsl:if>
+        </span>
+    </xsl:template>
+    
+    <!-- traitement des identifiants -->
+
+</xsl:stylesheet>

--- a/webapp/static/xslt2/tei2html.xsl
+++ b/webapp/static/xslt2/tei2html.xsl
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet 
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:tei="http://www.tei-c.org/ns/1.0" 
-    version="2.0">
-<xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>  
-<!-- <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.w3.org/1999/xhtml" version="2.0" exclude-result-prefixes="xs" xpath-default-namespace="http://www.tei-c.org/ns/1.0">
-<xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/> -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+	xpath-default-namespace="http://www.tei-c.org/ns/1.0"
+	xmlns="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs">
+	<xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>
+	<xsl:strip-space elements="*"/>
 	<!--
 	     group
-text
-front
+	     text
+	     front
 	     body
 	     div
 	     back
@@ -33,45 +30,45 @@ front
 	     objectName
 	     abbr
 	     expan
-fw
-gap
-
-rs
-ref
-date
-num
-cb
+	     fw
+	     gap
+	     rs
+	     ref
+	     date
+	     num
+	     cb
 	     supplied
 	     unclear
-surplus
-	     
+	     surplus
 	     sic
-orig
-reg
-soCalled
-title
-bibl
-label
-lg
-l
-graphic
-figure
-desc
-seg
-note
-
-	     -->
+	     orig
+	     reg
+	     soCalled
+	     title
+	     bibl
+	     label
+	     lg
+	     l
+	     graphic
+	     figure
+	     desc
+	     seg
+	     note -->
 	<xsl:template match="/">
 		<xsl:apply-templates/>
 	</xsl:template>
+	<xsl:template match="teiHeader"/>
+	<xsl:template match="TEI">
+		<xsl:apply-templates/>
+	</xsl:template>
 	<!-- liens et pointeurs -->
-    <xsl:template match="ptr[@target]">
-        <a href="{@target}">
-            <xsl:apply-templates select="@*"/>
-            <!--<xsl:call-template name="rendition"/>-->
-            <xsl:value-of select="normalize-space(@target)"/>
-        </a>
-    </xsl:template>
+	<xsl:template match="ptr[@target]">
+		<a href="{@target}">
+			<xsl:apply-templates select="@*"/>
+			<!--<xsl:call-template name="rendition"/>-->
+			<xsl:value-of select="normalize-space(@target)"/>
+		</a>
+	</xsl:template>
 	<!-- conversion des attributs @xmlid en @id -->
 	<xsl:template match="@xml:id">
 		<xsl:attribute name="id">
@@ -95,11 +92,47 @@ note
 		</span>
 	</xsl:template>
 	<!-- titres et divisions -->
+	<xsl:template match="text">
+		<section class="{local-name()}">
+			<xsl:apply-templates />
+		</section>
+	</xsl:template>
+	<xsl:template match="front | body | back">
+		<section class="{local-name()}">
+			<xsl:apply-templates select="@*|node()"/>
+		</section>
+	</xsl:template>
+	<xsl:template match="front/div[@xml:lang] | body/div[@xml:lang] | back/div[@xml:lang]">
+		<xsl:apply-templates/>
+	</xsl:template>
+	<xsl:template match="titlePage">
+		<header>
+			<xsl:apply-templates />
+		</header>
+	</xsl:template>
+	<xsl:template match="docTitle">
+		<xsl:apply-templates/>
+	</xsl:template>
+	<xsl:template match="titlePart">
+		<h1>
+			<xsl:apply-templates />
+		</h1>
+	</xsl:template>
+	<xsl:template match="docAuthor | docDate | docEdition">
+		<span class="{local-name()}">
+			<xsl:apply-templates />
+		</span>
+	</xsl:template>
+	<xsl:template match="div | p">
+		<xsl:element name="{local-name()}">
+			<xsl:apply-templates />
+		</xsl:element>
+	</xsl:template>
 	<xsl:template match="head">
 		<xsl:variable name="level" select="count(ancestor::div)"/>
 		<xsl:variable name="name" select="concat('h', $level)"/>
 		<xsl:element name="{$name}">
-			<xsl:apply-templates select="@*|node()"/>
+			<xsl:apply-templates />
 		</xsl:element>
 	</xsl:template>
 	<!-- listes -->
@@ -115,100 +148,126 @@ note
 	</xsl:template>
 	<xsl:template match="list">
 		<ul>
-			<xsl:apply-templates/>
+			<xsl:apply-templates />
 		</ul>
 	</xsl:template>
-		<xsl:template match="item/label">
+	<xsl:template match="item/label">
 		<span>
-			<xsl:apply-templates/>
+			<xsl:apply-templates />
 		</span>
 	</xsl:template>
 
 	<xsl:template match="item">
 		<li>
-			<xsl:apply-templates/>
+			<xsl:apply-templates />
 		</li>
 	</xsl:template>
 	<xsl:template match="item" mode="definition">
 		<dt>
-			<xsl:apply-templates/>
+			<xsl:apply-templates />
 		</dt>
 	</xsl:template>
 	<!-- citations -->
 	<xsl:template match="quote[not(ancestor::p)]">
 		<blockquote>
-			<xsl:apply-templates/>
+			<xsl:apply-templates />
 		</blockquote>
 	</xsl:template>
 	<xsl:template match="quote/cit">
 		<footer>
 			<!-- TODO créer un lien lorsqu'une référence est fournie -->
 			<cit>
-				<xsl:apply-templates/>
+				<xsl:apply-templates />
 			</cit>
 		</footer>
 	</xsl:template>
-
+	<!-- gap, etc. -->
+	<xsl:template match="gap">
+		<span class="{local-name()}">[…]</span>
+	</xsl:template>
+	<xsl:template match="supplied | unclear">
+		<span class="{local-name()}">
+			<xsl:text> [</xsl:text>
+				<xsl:apply-templates/>
+			<xsl:text>] </xsl:text>
+		</span>
+	</xsl:template>
+	<xsl:template match="sic">
+		<span class="{local-name()}">
+			<xsl:apply-templates/>
+			<xsl:text> [sic.]</xsl:text>
+		</span>
+	</xsl:template>
 	<!-- éléments inline -->
 	<xsl:template match="hi">
-		<span class="@rend">
-			<xsl:apply-templates/>
+		<span class="{local-name()} {@rend}">
+			<xsl:apply-templates />
 		</span>
+	</xsl:template>
+	<xsl:template match="hi[@rend='bold']">
+		<strong>
+			<xsl:apply-templates/>
+		</strong>
+	</xsl:template>
+	<xsl:template match="hi[@rend='italic']">
+		<em>
+			<xsl:apply-templates />
+		</em>
 	</xsl:template>
 	<xsl:template match="hi[@rend='superscript']">
 		<sup>
-			<xsl:apply-templates />
+			<xsl:apply-templates/>
 		</sup>
 	</xsl:template>
-		<xsl:template match="hi[@rend='underscript']">
+	<xsl:template match="hi[@rend='underscript']">
 		<sub>
-			<xsl:apply-templates />
+			<xsl:apply-templates/>
 		</sub>
 	</xsl:template>
 
 	<xsl:template match="foreign">
-      <span class="foreign">
-         <xsl:apply-templates/>
+		<span class="{local-name()}">
+			<xsl:apply-templates/>
 		</span>
 		<!-- TODO traiter les cas des éléments portant un @xml:lang -->
 	</xsl:template>
 	<xsl:template match="q | p/quote">
-      <xsl:text>«&#160;</xsl:text>
-      <xsl:apply-templates/>
-      <xsl:text>&#160;»</xsl:text>
-   </xsl:template>
+		<xsl:text>«&#160;</xsl:text>
+			<xsl:apply-templates/>
+		<xsl:text>&#160;»</xsl:text>
+	</xsl:template>
 	<!-- traitement des sources manuscrites -->
 	<xsl:template match="del">
 		<xsl:text>&#160;</xsl:text>
 		<del>
-			<xsl:apply-templates/>
+			<xsl:apply-templates />
 		</del>
 		<xsl:text>&#160;</xsl:text>
 	</xsl:template>
 	<!-- biblio -->
-	<xsl:template match="title"> 
-        <xsl:apply-templates />
-    </xsl:template>
-	<!-- mentions de responsabilités -->
-	<xsl:template match="principal"> 
-        <xsl:apply-templates />
-    </xsl:template>
-	<xsl:template match="persName"> 
-		<xsl:apply-templates select="forename" />
-		<xsl:apply-templates select="surname" />
+	<xsl:template match="title">
 		<xsl:apply-templates />
 	</xsl:template>
-	<xsl:template match="forename"> 
-        <xsl:apply-templates />
-	</xsl:template>	
-	<xsl:template match="surname"> 
-        <xsl:apply-templates />
-    </xsl:template>	
+	<!-- mentions de responsabilités -->
+	<xsl:template match="principal">
+		<xsl:apply-templates />
+	</xsl:template>
+	<xsl:template match="persName">
+		<xsl:apply-templates select="forename"/>
+		<xsl:apply-templates select="surname"/>
+		<xsl:apply-templates />
+	</xsl:template>
+	<xsl:template match="forename">
+		<xsl:apply-templates />
+	</xsl:template>
+	<xsl:template match="surname">
+		<xsl:apply-templates />
+	</xsl:template>
 	<!-- traitement par défaut -->
 	<xsl:template match="@*">
-        <xsl:copy/>
-    </xsl:template>
-    <!-- <xsl:template match="*"> 
+		<xsl:copy/>
+	</xsl:template>
+	<!-- <xsl:template match="*"> 
         <xsl:element name="{local-name()}">
             <xsl:apply-templates select="@*"/>
            <!-/- <xsl:call-template name="addID"/>
@@ -216,4 +275,40 @@ note
             <xsl:apply-templates select="node()"/>
         </xsl:element>
     </xsl:template> -->
+	<!--<xsl:template match="node()|@*" mode="#all">
+		<xsl:copy>
+			<xsl:apply-templates select="node()|@*" mode="#current"/>
+		</xsl:copy>
+	</xsl:template>-->
+	<!-- normalisation des espaces (http://wiki.tei-c.org/index.php/XML_Whitespace) -->
+	<xsl:template match="text()">
+		<xsl:choose>
+			<xsl:when
+				test="ancestor::*[@xml:space][1]/@xml:space='preserve'">
+				<xsl:value-of select="."/>
+			</xsl:when>
+			<xsl:otherwise>
+				<!-- Retain one leading space if node isn't first, has non-space content, and has leading space.-->
+				<xsl:if test="position()!=1 and matches(.,'^\s') and normalize-space()!=''">
+					<xsl:text> </xsl:text>
+				</xsl:if>
+				<xsl:value-of select="normalize-space(.)"/>
+				<xsl:choose>
+					<!-- node is an only child, and has content but it's all space -->
+					<xsl:when test="last()=1 and string-length()!=0 and normalize-space()=''">
+						<xsl:text> </xsl:text>
+					</xsl:when>
+					<!-- node isn't last, isn't first, and has trailing space -->
+					<xsl:when test="position()!=1 and position()!=last() and matches(.,'\s$')">
+						<xsl:text> </xsl:text>
+					</xsl:when>
+					<!-- node isn't last, is first, has trailing space, and has non-space content -->
+					<xsl:when test="position()=1 and matches(.,'\s$') and normalize-space()!=''">
+						<xsl:text> </xsl:text>
+					</xsl:when>
+				</xsl:choose>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+
 </xsl:stylesheet>

--- a/webapp/static/xslt2/tei2html.xsl
+++ b/webapp/static/xslt2/tei2html.xsl
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE xsl:stylesheet PUBLIC "Unofficial XSLT 1.0 DTD" "http://www.w3.org/1999/11/xslt10.dtd">
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.w3.org/1999/xhtml" version="2.0" exclude-result-prefixes="xs" xpath-default-namespace="http://www.tei-c.org/ns/1.0">
-	<xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="no"/>
+<xsl:stylesheet 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:tei="http://www.tei-c.org/ns/1.0" 
+    version="2.0">
+<xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>  
+<!-- <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.w3.org/1999/xhtml" version="2.0" exclude-result-prefixes="xs" xpath-default-namespace="http://www.tei-c.org/ns/1.0">
+<xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/> -->
 	<!--
 	     group
 text
@@ -180,16 +185,35 @@ note
 		</del>
 		<xsl:text>&#160;</xsl:text>
 	</xsl:template>
+	<!-- biblio -->
+	<xsl:template match="title"> 
+        <xsl:apply-templates />
+    </xsl:template>
+	<!-- mentions de responsabilités -->
+	<xsl:template match="principal"> 
+        <xsl:apply-templates />
+    </xsl:template>
+	<xsl:template match="persName"> 
+		<xsl:apply-templates select="forename" />
+		<xsl:apply-templates select="surname" />
+		<xsl:apply-templates />
+	</xsl:template>
+	<xsl:template match="forename"> 
+        <xsl:apply-templates />
+	</xsl:template>	
+	<xsl:template match="surname"> 
+        <xsl:apply-templates />
+    </xsl:template>	
 	<!-- traitement par défaut -->
 	<xsl:template match="@*">
         <xsl:copy/>
     </xsl:template>
-    <xsl:template match="*"> 
+    <!-- <xsl:template match="*"> 
         <xsl:element name="{local-name()}">
             <xsl:apply-templates select="@*"/>
-           <!-- <xsl:call-template name="addID"/>
-            <xsl:call-template name="rendition"/>-->
+           <!-/- <xsl:call-template name="addID"/>
+            <xsl:call-template name="rendition"/>-/->
             <xsl:apply-templates select="node()"/>
         </xsl:element>
-    </xsl:template>
+    </xsl:template> -->
 </xsl:stylesheet>

--- a/webapp/synopsx/_restxq/basket.xqm
+++ b/webapp/synopsx/_restxq/basket.xqm
@@ -30,7 +30,7 @@ import module namespace G = "synopsx.globals" at '../globals.xqm';
 
 import module namespace synopsx.webapp = 'synopsx.webapp' at 'webapp.xqm';
 import module namespace synopsx.models.tei = 'synopsx.models.tei' at '../models/tei.xqm';
-import module namespace synopsx.mapping.htmlWrapping = 'synopsx.mapping.htmlWrapping' at '../mapping/htmlWrapping.xqm';
+import module namespace synopsx.mappings.htmlWrapping = 'synopsx.mappings.htmlWrapping' at '../mappings/htmlWrapping.xqm';
 
 declare namespace tei = 'http://www.tei-c.org/ns/1.0'; (: déclaration pour test :)
 
@@ -59,7 +59,7 @@ function synopsx.basket:tei(
   (:
   : @TODO negociation de contenu
   :)
-  return synopsx.mapping.htmlWrapping:render($content, $options, $layout)
+  return synopsx.mappings.htmlWrapping:render($content, $options, $layout)
 };
 
 

--- a/webapp/synopsx/_restxq/blog.xqm
+++ b/webapp/synopsx/_restxq/blog.xqm
@@ -1,0 +1,177 @@
+xquery version '3.0' ;
+module namespace synopsx.blog = 'synopsx.blog' ;
+(:~
+ : This module is a RESTXQ blog with SynopsX
+ : @version 0.2 (Constantia edition)
+ : @date 2014-11-10 
+ : @author synopsx team
+ :
+ : This file is part of SynopsX.
+ : created by AHN team (http://ahn.ens-lyon.fr)
+ :
+ : SynopsX is free software: you can redistribute it and/or modify
+ : it under the terms of the GNU General Public License as published by
+ : the Free Software Foundation, either version 3 of the License, or
+ : (at your option) any later version.
+ :
+ : SynopsX is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ : See the GNU General Public License for more details.
+ : You should have received a copy of the GNU General Public License along 
+ : with SynopsX. If not, see <http://www.gnu.org/licenses/>
+ :
+ : @rmq the url scheme corresponds to a project level in SynopsX
+ :)
+
+import module namespace restxq = 'http://exquery.org/ns/restxq';
+ 
+import module namespace G = 'synopsx.globals' at '../globals.xqm' ;
+import module namespace synopsx.models.tei = 'synopsx.models.tei' at '../models/tei.xqm' ;
+import module namespace synopsx.mappings.htmlWrapping = 'synopsx.mappings.htmlWrapping' at '../mappings/htmlWrapping.xqm' ; 
+declare default function namespace 'synopsx.blog';
+
+
+(:~
+ : resource function for the blog
+ : 
+:)
+declare 
+  %restxq:path('/blog')
+function blog(){
+  <rest:redirect>{ '/blog/home' }</rest:redirect>
+};
+
+
+(:~
+ : resource function for the blog home
+ : 
+:)
+declare 
+  %restxq:path('/blog/home')
+function home(){
+  let $data    := synopsx.models.tei:listArticles()
+  let $options := map {'sorting' : 'descending'} (: todo :)
+  let $layout  := $G:TEMPLATES || 'blogHtml5.xhtml'
+  let $pattern  := $G:TEMPLATES || 'blogListSerif.xhtml'
+  return synopsx.mappings.htmlWrapping:wrapper($data, $options, $layout, $pattern)
+};
+
+
+(:~
+ : resource function for a blog entry
+ : 
+:)
+declare 
+  %restxq:path('/blog/{$entryId}')
+  %rest:produces("application/html")
+function article($entryId as xs:string){
+  let $data    := synopsx.models.tei:article($entryId)
+  let $options := map {}
+  let $layout  := $G:TEMPLATES || 'blogHtml5.xhtml'
+  let $pattern  := $G:TEMPLATES || 'blogArticleSerif.xhtml'
+  return synopsx.mappings.htmlWrapping:wrapper($data, $options, $layout, $pattern)
+};
+
+(:~
+ : resource function for a blog entry
+ : 
+:)
+declare 
+  %restxq:path('/blog/{$entryId}')
+  %rest:produces("application/xml")
+  %rest:produces("application/tei+xml")  
+function articleXml($entryId as xs:string){
+  let $lang := 'fr'
+  let $data := synopsx.models.tei:getXmlTeiById($entryId) 
+  return $data (: to serialize :)
+};
+
+(:~
+ : resource function for comments (if supported)
+ : 
+ : Collection des commentaires d'un billet de blog : 
+ : `guidesdeparis.net/blog/posts/{entryId}/{comments}`
+ : Item de commentaires d'un billet de blog 
+ : `guidesdeparis.net/blog/posts/{entryId}/{comments}/{commentId}`
+ :)
+
+(:~
+ : resource function to search blog posts
+ : 
+ : `guidesdeparis.net/blog/posts/search?q=query` 
+ : ou bien `guidesdeparis.net/blog/posts?q=query`
+ : ?? `added_after`, `blog`, `blog_tag`, `pmid`, `tag`, `term`
+ : 
+ :)
+declare 
+  %restxq:path('/blog/search')
+function search(){
+ 'toto'
+};
+
+
+(:~
+ : resource function for collection of tags
+ : 
+ :)
+declare
+  %restxq:path('/blog/tags')
+function tags(){
+  'todo'
+};
+
+
+(:~
+ : resource function for collection of blog entries by tag
+ : 
+ :)
+declare
+  %restxq:path('/blog/tags/{$tagId}')
+function entriesByTagId($tagId as xs:string){
+  'todo'
+};
+
+
+(:~
+ : resource function for collection of category
+ : 
+ :)
+declare
+  %restxq:path('/blog/categories')
+function categories(){
+  'todo'
+};
+
+
+(:~
+ : resource function for collection of blog entries by tag
+ : 
+ :)
+declare
+  %restxq:path('/blog/categories/{$categoryId}')
+function entriesByCategoryId($categoryId as xs:string){
+  'todo'
+};
+
+
+(:~
+ : resource function for collection of authors
+ : 
+ :)
+declare
+  %restxq:path('/blog/authors')
+function entriesByCategoryId(){
+  'todo'
+};
+
+
+(:~
+ : resource function for collection of category
+ : 
+ :)
+declare
+  %restxq:path('/blog/authors/{$authorId}')
+function categories($authorId as xs:string){
+  'todo'
+};

--- a/webapp/synopsx/_restxq/oai.xqm
+++ b/webapp/synopsx/_restxq/oai.xqm
@@ -1,0 +1,130 @@
+xquery version "3.0" ;
+module namespace synopsx.oai = 'synopsx.oai';
+(:~
+ : This module is the RESTXQ for OAI-PMH for SynopsX
+ : @version 0.2 (Constantia edition)
+ : @date 2014-11-10 
+ : @author synopsx team
+ :
+ : This file is part of SynopsX.
+ : created by AHN team (http://ahn.ens-lyon.fr)
+ :
+ : SynopsX is free software: you can redistribute it and/or modify
+ : it under the terms of the GNU General Public License as published by
+ : the Free Software Foundation, either version 3 of the License, or
+ : (at your option) any later version.
+ :
+ : SynopsX is distributed in the hope that it will be useful,
+ : but WITHOUT ANY WARRANTY; without even the implied warranty of
+ : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ : See the GNU General Public License for more details.
+ : You should have received a copy of the GNU General Public License along 
+ : with SynopsX. If not, see <http://www.gnu.org/licenses/>
+ :
+ :)
+
+declare default function namespace 'synopsx.oai';
+declare default element namespace "http://www.openarchives.org/OAI/2.0/";
+declare namespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+declare namespace xslt="http://basex.org/modules/xslt";
+import module namespace request = "http://exquery.org/ns/request";
+
+declare variable $synopsx.oai:tei2dc := "http://ahn-basex.cbp.ens-lyon.fr:8984/static/xsl/tei2dc.xsl";
+         
+
+
+declare %restxq:path("{$project}/oai")
+        %output:method("xml")
+        %rest:query-param("verb", "{$verb}", "")
+        %rest:query-param("identifier", "{$identifier}")
+        %rest:query-param("metadataPrefix", "{$metadataPrefix}")
+        %rest:query-param("from", "{$from}")
+        %rest:query-param("until", "{$until}")
+        %rest:query-param("set", "{$set}")
+        %rest:query-param("resumptionToken", "{$resumptionToken}")
+        %output:omit-xml-declaration("no")
+function index($project, $verb, $identifier, $metadataPrefix, $from, $until, $set, $resumptionToken) {
+  <OAI-PMH>
+      <responseDate>{fn:current-dateTime()}</responseDate>
+      <request>{request:uri()}?{request:query()}</request>
+      {switch ($verb) 
+        case 'GetRecord'
+          return synopsx.oai:GetRecord($project, $identifier, $metadataPrefix)
+        case 'Identify'
+          return synopsx.oai:Identify($project)
+        case 'ListIdentifiers'
+          return synopsx.oai:ListIdentifiers($project, $from, $until, $metadataPrefix, $set, $resumptionToken)
+        case 'ListMetadataFormats'
+          return synopsx.oai:ListMetadataFormats($project, $identifier)
+        case 'ListRecords'
+          return synopsx.oai:ListRecords($project, $from, $until, $metadataPrefix, $set, $resumptionToken)
+        case 'ListSets'
+          return synopsx.oai:ListSets($project, $resumptionToken)
+        case ''
+          return <error code="badVerb">No verb specified</error>
+        default
+          return <error code="badVerb">No such verb {$verb}</error>
+      }
+    </OAI-PMH>
+};
+
+declare function synopsx.oai:GetRecord($project, $identifier, $metadataPrefix){
+    <GetRecord>
+    </GetRecord>
+};
+
+declare function synopsx.oai:Identify($project){
+    <Identify>
+      <repositoryName>{$project}</repositoryName>
+      <baseURL>{request:uri()}</baseURL>
+      <protocolVersion>2.0</protocolVersion>
+      <adminEmail>ahn-equipe@ens-lyon.fr</adminEmail>
+      <earliestDatestamp></earliestDatestamp>
+      <deletedRecord></deletedRecord>
+      <granularity></granularity>
+    </Identify>
+};
+
+declare function synopsx.oai:ListIdentifiers($project, $from, $until, $metadataPrefix, $set, $resumptionToken){
+    <ListIdentifiers>
+    </ListIdentifiers>
+};
+
+declare function synopsx.oai:ListMetadataFormats($project, $identifier){
+    <ListMetadataFormats>
+      <metadataFormat>
+      <metadataPrefix>oai_dc</metadataPrefix>
+      <schema>http://www.openarchives.org/OAI/2.0/oai_dc.xsd</schema>
+      <metadataNamespace>http://www.openarchives.org/OAI/2.0/oai_dc/</metadataNamespace>
+      </metadataFormat>
+    </ListMetadataFormats>
+};
+
+declare function synopsx.oai:ListRecords($project, $from, $until, $metadataPrefix, $set, $resumptionToken){
+    <ListRecords>
+  
+    </ListRecords>
+};
+
+declare function synopsx.oai:ListSets($project, $resumptionToken){
+    <ListSets>
+      {
+        for $set in db:open($project)//*:teiCorpus 
+          return 
+          <set>
+            <setSpec>
+              {fn:string-join($set/ancestor-or-self::*:teiCorpus/@xml:id,':')}
+            </setSpec>
+            <setName>
+              {$set/*:teiHeader/*:fileDesc/*:titleStmt/*:title/text()}
+            </setName>
+            <setDescription>
+              { if ($set/*:teiHeader) then
+                xslt:transform($set/*:teiHeader, $synopsx.oai:tei2dc)
+                else ''
+              }
+            </setDescription>
+          </set>
+      }
+    </ListSets>
+};

--- a/webapp/synopsx/_restxq/users.xqm
+++ b/webapp/synopsx/_restxq/users.xqm
@@ -30,7 +30,7 @@ import module namespace Session = "http://basex.org/modules/session";
 import module namespace synopsx.webapp = 'synopsx.webapp' at 'webapp.xqm';
 
 import module namespace synopsx.models.tei = 'synopsx.models.tei'  at '../models/tei.xqm';
-import module namespace synopsx.mapping.htmlUsers = 'synopsx.mapping.htmlUsers'  at '../mapping/htmlUsers.xqm';
+import module namespace synopsx.mappings.htmlUsers = 'synopsx.mappings.htmlUsers'  at '../mappings/htmlUsers.xqm';
 
 
 (:~
@@ -49,7 +49,7 @@ function synopsx.users:create-user() {
   let $layout := map {
     'layout' := $G:HOME || 'templates/html.xhtml'
   }
-  return synopsx.mapping.htmlUsers:create-user($content, $options, $layout)
+  return synopsx.mappings.htmlUsers:create-user($content, $options, $layout)
 };
 
 
@@ -71,7 +71,7 @@ function synopsx.users:list-user(
   let $layout := map {
     'layout' := $G:HOME || 'templates/html.xhtml'
   }
-  return synopsx.mapping.htmlUsers:list-user($content, $options, $layout)
+  return synopsx.mappings.htmlUsers:list-user($content, $options, $layout)
 };
 
 (:~

--- a/webapp/synopsx/_restxq/webapp.xqm
+++ b/webapp/synopsx/_restxq/webapp.xqm
@@ -45,7 +45,7 @@ declare
   %output:method("xhtml") (: TODO content negociation :)
   function corpusList(){
     let $options := map {} (: specify an xslt mode and other kind of option :)
-    let $layout := $G:TEMPLATES || 'html.xhtml' (: global layout file template :)
+    let $layout := $G:TEMPLATES || 'simpleHtml.xhtml' (: global layout file template :)
     let $pattern := $G:TEMPLATES || 'tei_mentioned_list.xhtml' (: fragment layout template file (to be repeated or not) :)
     return synopsx.mapping.htmlWrapping:globalWrapper
       (

--- a/webapp/synopsx/_restxq/webapp.xqm
+++ b/webapp/synopsx/_restxq/webapp.xqm
@@ -29,7 +29,7 @@ import module namespace G = "synopsx.globals" at '../globals.xqm';
 import module namespace synopsx.models.tei = 'synopsx.models.tei' at '../models/tei.xqm';
 
 (: Put here all import declarations for mapping according to models :)
-import module namespace synopsx.mapping.htmlWrapping = 'synopsx.mapping.htmlWrapping' at '../mapping/htmlWrapping.xqm';
+import module namespace synopsx.mappings.htmlWrapping = 'synopsx.mappings.htmlWrapping' at '../mappings/htmlWrapping.xqm';
 
 (: Use a default namespace :)
 declare default function namespace 'synopsx.webapp';
@@ -47,7 +47,7 @@ declare
     let $options := map {} (: specify an xslt mode and other kind of option :)
     let $layout := $G:TEMPLATES || 'simpleHtml.xhtml' (: global layout file template :)
     let $pattern := $G:TEMPLATES || 'tei_mentioned_list.xhtml' (: fragment layout template file (to be repeated or not) :)
-    return synopsx.mapping.htmlWrapping:globalWrapper
+    return synopsx.mappings.htmlWrapping:globalWrapper
       (
         synopsx.models.tei:listCorpus(), $options, $layout, $pattern
       )

--- a/webapp/synopsx/globals.xqm
+++ b/webapp/synopsx/globals.xqm
@@ -1,5 +1,5 @@
-xquery version "3.0" ;
-module namespace G = "synopsx.globals";
+xquery version '3.0' ;
+module namespace G = 'synopsx.globals';
 (:~
  : This module gives the globals variables for SynopsX
  : @version 0.2 (Constantia edition)
@@ -44,8 +44,9 @@ declare variable $G:VIEWS :=  $G:SYNOPSX_DIR || '/synopsx/views/';
 declare variable $G:PROJECTS :=  $G:SYNOPSX_DIR || '/synopsx/projects/';
 
 (: Section dedicated to databases, specificities of a project:)
-declare variable $G:DBNAME := "gdp";
-
+declare variable $G:DBNAME := 'gdp';
+declare variable $G:BLOGDB := 'blog';
+declare variable $G:PROJECTEDITIONROOT := 'http://localhost:8984/gdp/';
 
 (:~ Status: everything ok. :)
 declare variable $G:OK := '1';

--- a/webapp/synopsx/globals.xqm
+++ b/webapp/synopsx/globals.xqm
@@ -28,10 +28,10 @@ declare variable $G:HOME := file:base-dir();
 (: file:parent(static-base-uri()) || '../../repo/synopsx/templates/html.xhtml'; :)
 declare variable $G:WEBAPP := file:current-dir() || 'webapp/';
 
-declare variable $G:_RESTXQ := $G:WEBAPP || 'synopsx/_restxq/';
-declare variable $G:MODELS :=  $G:WEBAPP || 'synopsx/models/';
-declare variable $G:TEMPLATES :=  $G:WEBAPP || 'synopsx/templates/';
-declare variable $G:MAPPING :=  $G:WEBAPP || 'synopsx/mapping/';
+declare variable $G:_RESTXQ := $G:HOME || '_restxq/';
+declare variable $G:MODELS :=  $G:HOME || 'models/';
+declare variable $G:TEMPLATES :=  $G:HOME || 'templates/';
+declare variable $G:MAPPING :=  $G:HOME || 'mapping/';
 
 (:~ Status: everything ok. :)
 declare variable $G:OK := '1';

--- a/webapp/synopsx/globals.xqm
+++ b/webapp/synopsx/globals.xqm
@@ -32,7 +32,7 @@ declare variable $G:SYNOPSX_DIR := substring-before(file:base-dir(), 'webapp/syn
 declare variable $G:_RESTXQ := $G:HOME || '_restxq/';
 declare variable $G:MODELS :=  $G:HOME || 'models/';
 declare variable $G:TEMPLATES :=  $G:HOME || 'templates/';
-declare variable $G:MAPPING :=  $G:HOME || 'mapping/'; 
+declare variable $G:MAPPINGS :=  $G:HOME || 'mappings/'; 
 :)
 
 declare variable $G:WEBAPP := file:current-dir() || 'webapp/'; (: TO CHECK :)
@@ -41,9 +41,11 @@ declare variable $G:_RESTXQ := $G:SYNOPSX_DIR || '/synopsx/_restxq/';
 declare variable $G:MODELS :=  $G:SYNOPSX_DIR || '/synopsx/models/';
 declare variable $G:TEMPLATES :=  $G:SYNOPSX_DIR || '/synopsx/templates/';
 declare variable $G:VIEWS :=  $G:SYNOPSX_DIR || '/synopsx/views/';
+declare variable $G:PROJECTS :=  $G:SYNOPSX_DIR || '/synopsx/projects/';
 
 (: Section dedicated to databases, specificities of a project:)
 declare variable $G:DBNAME := "gdp";
+
 
 (:~ Status: everything ok. :)
 declare variable $G:OK := '1';

--- a/webapp/synopsx/globals.xqm
+++ b/webapp/synopsx/globals.xqm
@@ -47,6 +47,7 @@ declare variable $G:PROJECTS :=  $G:SYNOPSX_DIR || '/synopsx/projects/';
 declare variable $G:DBNAME := 'gdp';
 declare variable $G:BLOGDB := 'blog';
 declare variable $G:PROJECTEDITIONROOT := 'http://localhost:8984/gdp/';
+declare variable $G:PROJECTBLOGROOT := 'http://localhost:8984/blog/';
 
 (:~ Status: everything ok. :)
 declare variable $G:OK := '1';

--- a/webapp/synopsx/mapping/htmlWrapping.xqm
+++ b/webapp/synopsx/mapping/htmlWrapping.xqm
@@ -55,9 +55,8 @@ declare function wrapper($data as map(*), $options, $layout as xs:string, $patte
       let $key := fn:replace($text, '\{|\}', '')
       let $value := $meta($key) 
     return 
-      if ($key = 'content') 
-        then replace node $text with pattern($meta, $contents, $options, $pattern)
-        else replace node $text with $value
+      if ($key = 'content') then replace node $text with pattern($meta, $contents, $options, $pattern)
+      else replace node $text with (xslt:transform($value, '../../static/xslt2/tei2html5.xsl'))
   )
 };
 
@@ -79,7 +78,7 @@ declare function pattern($meta as map(*), $contents  as map(*), $options, $patte
       where fn:starts-with($text, '{') 
         and fn:ends-with($text, '}')
       let $key := fn:replace($text, '\{|\}', '') (: get the text between braces :)
-      let $value := $content($key) (: get the content corresponding to the key :)
+      let $value := $content($key)  (: get the content corresponding to the key :)
       return replace node $text with $value (: replace text between braces with the content :)
     )
   })

--- a/webapp/synopsx/mappings/htmlUsers.xqm
+++ b/webapp/synopsx/mappings/htmlUsers.xqm
@@ -1,7 +1,7 @@
 xquery version "3.0" ;
-module namespace synopsx.mapping.htmlBasket = 'synopsx.mapping.htmlBasket';
+module namespace synopsx.mappings.htmlUsers = 'synopsx.mappings.htmlUsers';
 (:~
- : This module is an HTML demo for a user's basket
+ : This module is an HTML demo for Users
  : @version 0.2 (Constantia edition)
  : @date 2014-11-10 
  : @author synopsx team
@@ -28,39 +28,20 @@ import module namespace Session = "http://basex.org/modules/session";
 import module namespace G = "synopsx.globals" at '../globals.xqm';
 
 (: Use a default namespace :)
-declare default function namespace 'synopsx.mapping.htmlBasket';
+declare default function namespace 'synopsx.mappings.htmlUsers';
 
 (:~
- : This function is a form to register an user 
+ : This function create a user
  :)
-declare function form($content, $options, $layout) {
+declare function create-user($content, $options, $layout) {
   let $tmpl := fn:doc($layout('layout'))
   
   return $tmpl update (
     replace node .//*:div[@id='content'] with (
-      let $items := $content('items')
-      let $status := $content('status')
-      return
-        <form action="/tei/select" method='post'>
-          { status($status) }
-          <input type='submit' value='ORDER'/>
-          <br/>
-          User: <input type='text' name='user' value='{ Session:get("user") }'/>
-          <br/>
-          {
-            let $selected := Session:get("selected")/item
-            for $item at $p in $items
-            return (
-              element input {
-                attribute type { 'checkbox' },
-                attribute name { 'items' },
-                attribute checked { 'checked' }[$p = $selected],
-                attribute value { $p },
-                $item/text()
-              },
-              <br/>
-            )
-        }</form>
+      <form action="/create-user/apply" method='post'>
+        <input type='text' name='name'/>
+        <input type='submit' value='Create'/>
+      </form>
     ),
     replace value of node .//*:title with $content('title')
   )
@@ -68,9 +49,33 @@ declare function form($content, $options, $layout) {
 
 
 (:~
- : This function check user status and return a message
- : 
- : @rmq To mutualise 
+ : This function list users
+ :)
+declare function list-user($content, $options, $layout) {
+  let $tmpl := fn:doc($layout('layout'))
+  return $tmpl update (
+    replace node .//*:div[@id='content'] with (
+      status($content('status')),
+      <ul>
+      {
+        for $user in db:open('users')/users/user
+        let $name := $user/@name/fn:string()
+        (: let $name := $user/@name/string() :)
+        return 
+          <li>{ $name }  (<a href="delete-user/apply?name={ $name }">delete</a>)</li>
+      }
+      </ul>,
+      <form action='create-user'>
+        <input type='submit' value='Create User'/>
+      </form>
+    ),
+    replace value of node .//*:title with $content('title')
+  )
+};
+
+
+(:~
+ : This function shows status
  :)
 declare function status(
   $status as xs:string

--- a/webapp/synopsx/mappings/htmlWrapping.xqm
+++ b/webapp/synopsx/mappings/htmlWrapping.xqm
@@ -1,5 +1,5 @@
 xquery version "3.0" ;
-module namespace synopsx.mapping.htmlWrapping = 'synopsx.mapping.htmlWrapping';
+module namespace synopsx.mappings.htmlWrapping = 'synopsx.mappings.htmlWrapping';
 (:~
  : This module is an HTML mapping for templating
  : @version 0.2 (Constantia edition)
@@ -27,7 +27,7 @@ import module namespace G = "synopsx.globals" at '../globals.xqm';
 
 
 (: use to avoid to prefix functions name:)
-declare default function namespace 'synopsx.mapping.htmlWrapping'; 
+declare default function namespace 'synopsx.mappings.htmlWrapping'; 
 
 (: Specify namespaces used by the models:)
 declare namespace tei = 'http://www.tei-c.org/ns/1.0'; 

--- a/webapp/synopsx/models/tei.xqm
+++ b/webapp/synopsx/models/tei.xqm
@@ -93,8 +93,8 @@ declare function corpusHeader($item as element()) {
 declare function listCorpus() {
   let $corpus := db:open($synopsx.models.tei:db) (: openning the database:)
   let $meta as map(*) := {
-    'title' : 'Liste des corpus',
-    'quantity' : fn:count($corpus/*/tei:teiCorpus)
+    'title' : <tei:title>Liste des corpus</tei:title>,
+    'quantity' : <tei:label>{fn:count($corpus/*/tei:teiCorpus)}</tei:label>
     }
   let $content as map(*) := map:merge(
     for $item in $corpus//tei:TEI/tei:teiHeader (: every teiHeader is add to the map with arbitrary key and the result of  corpusHeader() function apply to this teiHeader:)

--- a/webapp/synopsx/models/tei.xqm
+++ b/webapp/synopsx/models/tei.xqm
@@ -28,41 +28,98 @@ import module namespace G = "synopsx.globals" at '../globals.xqm'; (: import glo
 declare default function namespace 'synopsx.models.tei'; (: This is the default namespace:)
 declare namespace tei = 'http://www.tei-c.org/ns/1.0'; (: Add namespaces :)
 
-
 (:~
- : This function return the corpus title
+ : This function creates a map of two maps : one for metadata, one for content data
  :)
-declare function title() as element(){ 
-  (db:open($G:DBNAME)//tei:titleStmt/tei:title)[1]
-}; 
- 
-(:~
- : This function return a titles list
- :)
-declare function listItems() as element()* { 
-  db:open($G:DBNAME)//tei:titleStmt/tei:title
+declare function listArticles() {
+  let $texts := db:open($G:BLOGDB)//tei:TEI
+  let $lang := 'fr'
+  let $meta := {
+    'title' : 'Liste d’articles', 
+    'quantity' : getQuantity($texts, 'article'), (: @todo internationalize :)
+    'author' : getAuthors($texts),
+    'copyright'  : getCopyright($texts),
+    'description' : getDescription($texts, $lang),
+    'keywords' : getKeywords($texts, $lang)
+    }
+  let $content := map:merge(
+    for $item in $texts/tei:teiHeader 
+    order by ($item//tei:publicationStmt/tei:date/@when) descending (: sans effet :)
+    return  map:entry( fn:generate-id($item), header($item) )
+    )
+  return  map{
+    'meta'    : $meta,
+    'content' : $content
+    }
 };
 
+(:~
+ : This function creates a map of two maps : one for metadata, one for content data
+ :)
+declare function article($entryId as xs:string) {
+  let $article := db:open($G:BLOGDB)/tei:TEI[//tei:sourceDesc[@xml:id=$entryId]]
+  let $lang := 'fr'
+  let $meta := {
+    'title' : getTitles($article, $lang), 
+    'author' : getAuthors($article),
+    'copyright'  : getCopyright($article),
+    'description' : getDescription($article, $lang),
+    'keywords' : getKeywords($article, $lang)
+    }
+  let $content as map(*) := map:merge(
+    map:entry( fn:generate-id($article), header($article) )
+    )
+  return  map{
+    'meta'    : $meta,
+    'content' : $content
+    }
+};
+
+(:~
+ : This function creates a map for a corpus item with teiHeader 
+ :
+ : @param $item a corpus item
+ : @return a map with content for each item
+ : @rmq subdivised with let to construct complex queries (EC2014-11-10)
+ :)
+declare function header($item as element()) {
+  let $lang := 'fr'
+  let $dateFormat := 'jjmmaaa'
+  return map {
+    'title' : getTitle($item, $lang),
+    'subtitle' : getSubtitle($item, $lang),
+    'date' : getDate($item, $dateFormat),
+    'author' : getAuthors($item),
+    'tei' : $item,
+    'url' : getUrl($item, $lang)
+    (: ', teiAbstract' : getAbstract($item, $lang) :)
+  }
+};
 
 (:~
  : This function creates a map of two maps : one for metadata, one for content data
  :)
 declare function listCorpus() {
-  let $corpus := db:open($G:DBNAME) (: openning the database:)
-  let $meta as map(*) := {
-    'title' : <tei:title>Liste des corpus</tei:title>,
-    'quantity' : <tei:label>{fn:count($corpus/*/tei:teiCorpus)}</tei:label>
+  let $texts := db:open($G:DBNAME)//tei:teiCorpus
+  let $lang := 'fr'
+  let $meta := {
+    'title' : 'Liste d’articles', 
+    'quantity' : getQuantity($texts, 'article'), (: @todo internationalize :)
+    'author' : getAuthors($texts),
+    'copyright'  : getCopyright($texts),
+    'description' : getDescription($texts, $lang),
+    'keywords' : getKeywords($texts, $lang)
     }
   let $content as map(*) := map:merge(
-    for $item in $corpus//tei:TEI/tei:teiHeader (: every teiHeader is add to the map with arbitrary key and the result of  corpusHeader() function apply to this teiHeader:)
-    return  map:entry(fn:generate-id($item), corpusHeader($item))
+    for $item in $texts/tei:teiHeader 
+    order by $item//tei:publicationStmt/tei:date/@when (: sans effet :)
+    return  map:entry( fn:generate-id($item), header($item) )
     )
   return  map{
-    'meta'       : $meta,
-    'content'    : $content
-  }
+    'meta'    : $meta,
+    'content' : $content
+    }
 };
-
 
 (:~
  : This function creates a map for a corpus item with teiHeader 
@@ -144,4 +201,189 @@ declare function mentioned($item) as map(*) {
     'lang' : fn:string($item/@*:lang),
     'term' : $item/text()
   }
+};
+
+(:~
+ : ~:~:~:~:~:~:~:~:~
+ : tei builders
+ : ~:~:~:~:~:~:~:~:~
+ :)
+
+(:~
+ : this function get abstract
+ : @param $content texts to process
+ : @return a tei abstract
+ :)
+declare function getAbstract($content as element()*, $lang as xs:string){
+  $content//tei:front//tei:div[@type='abstract'][fn:starts-with(@xml:lang, $lang)]
+};
+
+(:~
+ : this function get authors
+ : @param $content texts to process
+ : @return a distinct-values comma separated list
+ :)
+declare function getAuthors($content as element()*){
+  fn:string-join(
+    fn:distinct-values(
+      for $name in $content//tei:respStmt[tei:resp/@key='aut'] | $content//tei:principal
+      return fn:normalize-space(getName($name))
+      ), 
+    ', ')
+};
+
+(:~
+ : this function get the licence url
+ : @param $content texts to process
+ : @return the @target url of licence
+ :
+ : @rmq if a sequence get the first one
+ : @toto make it better !
+ :)
+declare function getCopyright($content){
+  ($content//tei:licence/@target)[1]
+};
+
+(:~
+ : this function get date
+ : @param $content texts to process
+ : @param $dateFormat a normalized date format code
+ : @return a date string in the specified format
+ : @todo formats
+ :)
+declare function getDate($content as element()*, $dateFormat as xs:string){
+  fn:normalize-space(
+    $content//tei:publicationStmt/tei:date
+  )
+};
+
+(:~
+ : this function get description
+ : @param $content texts to process
+ : @param $lang iso langcode starts
+ : @return a comma separated list of 90 first caracters of div[@type='abstract']
+ :)
+declare function getDescription($content as element()*, $lang as xs:string){
+  fn:string-join(
+    for $abstract in $content//tei:div[parent::tei:div[fn:starts-with(@xml:lang, $lang)]][@type='abstract']/tei:p 
+    return fn:substring(fn:normalize-space($abstract), 0, 90),
+    ', ')
+};
+
+(:~
+ : this function get keywords
+ : @param $content texts to process
+ : @param $lang iso langcode starts
+ : @return a comma separated list of values
+ :)
+declare function getKeywords($content as element()*, $lang as xs:string){
+  fn:string-join(
+    for $terms in fn:distinct-values($content//tei:keywords[fn:starts-with(@xml:lang, $lang)]/tei:term) 
+    return fn:normalize-space($terms), 
+    ', ')
+};
+
+(:~
+ : this function serialize persName
+ : @param $named named content to process
+ : @return concatenate forename and surname
+ :)
+declare function getName($named as element()*){
+  fn:normalize-space(
+    for $person in $named/tei:persName 
+    return ($person/tei:forename || ' ' || $person/tei:surname)
+    )
+};
+
+(:~
+ : this function built a quantity message
+ : @param $content texts to process
+ : @return concatenate quantity and a message
+ : @toto to internationalize
+ :)
+declare function getQuantity($content as element()*, $unit as xs:string){
+  fn:normalize-space(
+    if (fn:count($content)>1) 
+      then fn:count($content) || ' ' || $unit || 's disponibles'
+      else fn:count($content) || $unit || ' disponible'
+    )
+};
+
+(:~
+ : this function get sub-title
+ : @param $content texts to process
+ : @param $lang iso langcode starts
+ : @return a string of comma separated titles
+ :)
+declare function getSubtitle($content as element()*, $lang as xs:string){
+  fn:string-join(
+    fn:normalize-space(
+      for $title in $content//tei:titleStmt/tei:title[@type='sub']
+      return $title[fn:starts-with(@xml:lang, $lang)]
+      ),
+    ', ')
+};
+
+(:~
+ : this function get tei doc by id
+ : @param $id documents id to retrieve
+ : @return a plain xml-tei document
+ :)
+declare function getXmlTeiById($id as xs:string){
+  db:open($G:BLOGDB)//tei:TEI[//tei:sourceDesc[@xml-id=$id]]
+};
+
+(:~
+ : this function get title
+ : @param $content texts to process
+ : @param $lang iso langcode starts
+ : @return a string of comma separated titles
+ :)
+declare function getTitle($content as element()*, $lang as xs:string){
+  fn:string-join(
+    fn:normalize-space(
+      for $title in $content//tei:titleStmt/tei:title[@type='main']
+      return $title[fn:starts-with(@xml:lang, $lang)]
+      ),
+    ', ')
+};
+
+(:~
+ : this function get titles
+ : @param $content texts to process
+ : @param $lang iso langcode starts
+ : @return a string of comma separated titles
+ :)
+declare function getTitles($content as element()*, $lang as xs:string){
+  fn:string-join(
+    for $title in $content//tei:titleStmt/tei:title
+    return fn:normalize-space($title[fn:starts-with(@xml:lang, $lang)]),
+    ', ')
+};
+
+(:~
+ : this function get url
+ : @param $content texts to process
+ : @param $lang iso langcode starts
+ : @return a string of comma separated titles
+ : @toto print the real uri
+ :)
+declare function getUrl($content as element()*, $lang as xs:string){
+  $G:PROJECTBLOGROOT || $content//tei:sourceDesc/@xml:id
+};
+
+
+
+(:~
+ : This function return the corpus title
+ :)
+declare function title() as element(){ 
+  (db:open($G:DBNAME)//tei:titleStmt/tei:title)[1]
+}; 
+ 
+(:~
+ : This function return a titles list
+ :)
+declare function listItems() as element()* { 
+  db:open($G:DBNAME)//tei:titleStmt/tei:title
 };

--- a/webapp/synopsx/models/tei.xqm
+++ b/webapp/synopsx/models/tei.xqm
@@ -47,7 +47,7 @@ declare function listItems() as element()* {
 (:~
  : This function creates a map of two maps : one for metadata, one for content data
  :)
-declare function listCorpus() {
+declare function listCorpusOrig() {
   let $corpus := db:open($synopsx.models.tei:db) (: openning the database:)
   let $meta as map(*) := {
     'title' : 'Liste des corpus' (: title page:)
@@ -83,5 +83,25 @@ declare function corpusHeader($item as element()) {
     'title'      : $title ,
     'date'       : $date ,
     'principal'  : $principal
+  }
+};
+
+
+(:~
+ : This function creates a map of two maps : one for metadata, one for content data
+ :)
+declare function listCorpus() {
+  let $corpus := db:open($synopsx.models.tei:db) (: openning the database:)
+  let $meta as map(*) := {
+    'title' : 'Liste des corpus',
+    'quantity' : fn:count($corpus/*/tei:teiCorpus)
+    }
+  let $content as map(*) := map:merge(
+    for $item in $corpus//tei:TEI/tei:teiHeader (: every teiHeader is add to the map with arbitrary key and the result of  corpusHeader() function apply to this teiHeader:)
+    return  map:entry(fn:generate-id($item), corpusHeader($item))
+    )
+  return  map{
+    'meta'       : $meta,
+    'content'    : $content
   }
 };

--- a/webapp/synopsx/models/tei.xqm
+++ b/webapp/synopsx/models/tei.xqm
@@ -28,7 +28,7 @@ import module namespace G = "synopsx.globals" at '../globals.xqm'; (: import glo
 declare default function namespace 'synopsx.models.tei'; (: This is the default namespace:)
 declare namespace tei = 'http://www.tei-c.org/ns/1.0'; (: Add namespaces :)
  
-declare variable $synopsx.models.tei:db := "gdpTei"; (: dbname TODO choose an implementation :)
+declare variable $synopsx.models.tei:db := "gdp"; (: dbname TODO choose an implementation :)
 
 (:~
  : This function return the corpus title

--- a/webapp/synopsx/templates/blogArticleSerif.xhtml
+++ b/webapp/synopsx/templates/blogArticleSerif.xhtml
@@ -1,0 +1,12 @@
+<article class="type-system-serif">
+  <header>
+    <p class="type">Article de blog</p>
+    <h1>{title}</h1>
+    <h2>{subtitle}</h2>
+    <p class="meta">Publié le <span class="date">{date}</span>, par <span class="author">{author}</span></p>
+    <hr/>
+  </header>
+  <section class="text">{tei}</section>
+  <hr/>
+  <p class="author">{author}</p>
+</article>

--- a/webapp/synopsx/templates/blogHtml5.xhtml
+++ b/webapp/synopsx/templates/blogHtml5.xhtml
@@ -1,0 +1,106 @@
+<html xmlns="http://www.w3.org/1999/xhtml" lang="fr" xml:lang="fr">
+   <head>
+      <meta charset="utf-8" />
+      <title>{title}</title>
+      <meta name="description" content="{description}" />
+      <meta name="author" content="{author}" />
+      <meta name="keywords" content="{keywords}" />
+      <link rel="copyright" href="{copyright}"/>
+      <link href="/static/gdpStatic/css/main.css" rel="stylesheet" />
+      <script src="plugin.js"></script>
+      <!-- ajouter js pour lt IE 9 -->
+   </head>
+   <body>
+     <header class="navigation" id="nav">
+       <div class="navigation-wrapper">
+         <a href="/home" class="logo">
+           <img src="/static/gdpStatic/img/monument.svg" alt="Logo Image"/>
+         </a>
+         <a href="" class="navigation-menu-button" id="js-mobile-menu">MENU</a>
+       <div class="nav">
+       <ul id="navigation-menu">
+         <li class="nav-link"><a href="/blog">Blog</a></li>
+         <li class="nav-link"><a href="/about">À propos</a></li>
+         <li class="nav-link more">
+           <a href="/gdp/corpus">Les Guides</a>
+           <ul class="submenu">
+             <li><a href="/gdp">Consulter</a></li>
+             <li><a href="/gdp/cartography">Cartographie</a></li>
+             <li><a href="/gdp/index">Index</a></li>
+             <li><a href="/gdp/bibliography">Bibliographie</a></li>
+           </ul>
+         </li>
+       </ul>
+    </div>
+    <div class="navigation-tools">
+      <div class="search-bar">
+        <div class="search-and-submit">
+          <input type="search" placeholder="Enter Search" />
+          <button type="submit">
+            <img src="https://raw.githubusercontent.com/thoughtbot/refills/master/source/images/search-icon.png" alt="Search Icon"/>
+          </button>
+        </div>
+      </div>
+      <a href="javascript:void(0)" class="sign-up">Sign Up</a>
+    </div>
+  </div>
+</header>
+     <main>
+  <div>{content}</div>
+</main>
+     <footer class="footer">
+  <div class="footer-logo">
+    <img src="/static/gdpStatic/img/monument.svg" alt="Logo image"/>
+  </div>
+  <div class="footer-links">
+    <ul>
+      <li><h3>Contenu</h3></li>
+      <li><a href="/gdp">Les Guides</a></li>
+      <li><a href="/blog">Blog</a></li>
+      <li><a href="/about">À propos</a></li>
+    </ul>
+    <ul>
+      <li><h3>Suivez-nous</h3></li>
+      <li><a href="javascript:void(0)">Facebook</a></li>
+      <li><a href="https://twitter.com/emchateau">Twitter</a></li>
+      <li><a href="https://github.com/guidesDeParis/">GitHub</a></li>
+    </ul>
+    <ul>
+      <li><h3>Informations légales</h3></li>
+      <li><a href="javascript:void(0)">Conditions d'utilisation</a></li>
+      <li><a href="javascript:void(0)">Politique de confidentialité</a></li>
+    </ul>
+  </div>
+
+  <hr/>
+
+  <p>"Fluctuat nec mergitur" – Il est battu par les flots, mais ne sombre pas.</p>
+</footer>
+     <!-- script menu -->
+     <script><![CDATA[
+      $(document).ready(function() {
+  var menu = $('#navigation-menu');
+  var menuToggle = $('#js-mobile-menu');
+  var signUp = $('.sign-up');
+
+  $(menuToggle).on('click', function(e) {
+    e.preventDefault();
+    menu.slideToggle(function(){
+      if(menu.is(':hidden')) {
+        menu.removeAttr('style');
+      }
+    });
+  });
+
+  // underline under the active nav item
+  $(".nav .nav-link").click(function() {
+    $(".nav .nav-link").each(function() {
+      $(this).removeClass("active-nav-item");
+    });
+    $(this).addClass("active-nav-item");
+    $(".nav .more").removeClass("active-nav-item");
+  });
+});
+  ]]></script>
+   </body>
+</html>

--- a/webapp/synopsx/templates/blogListSerif.xhtml
+++ b/webapp/synopsx/templates/blogListSerif.xhtml
@@ -1,0 +1,11 @@
+<article class="serif">
+  <header>
+    <p class="type">Article de blog</p>
+    <h1>{title}</h1>
+    <h2>{subtitle}</h2>
+    <p class="meta">Publié le <span class="date">{date}</span>, par <span class="author">{author}</span></p>
+    <p class="abstract">{teiAbstract}</p>
+    <a href="{url}" class="read-more">Lire la suite <span>&gt;</span></a>
+    <hr/>
+  </header>  
+</article>

--- a/webapp/synopsx/templates/chapter_tei.xhtml
+++ b/webapp/synopsx/templates/chapter_tei.xhtml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <article class="section" xmlns="http://www.w3.org/1999/xhtml">
   <header>
-    <h1 id="title">{title}</h1>
-    <h2 id="date">{date}</h2>
+    <h1>{title}</h1>
+    <h2>{date}</h2>
   </header>
-  <section id="principal">{principal}</section>
+  <section>{principal}</section>
 </article>

--- a/webapp/synopsx/templates/chapter_tei.xhtml
+++ b/webapp/synopsx/templates/chapter_tei.xhtml
@@ -1,14 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- 
-  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ 
-   a SynopsX' template fragment (polyglot document) 
-   @see http://www.w3.org/TR/html-polyglot/
-   @todo apply ARIA accessibility standards http://www.w3.org/WAI/PF/aria/ 
-   @todo use xquery so the comment won't appears in the result doc
-   @rmq this is the xml fragment used by XQueries, the appropriate DOCTYPE is given by rendering
-  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ 
--->
-
 <article class="section" xmlns="http://www.w3.org/1999/xhtml">
   <header>
     <h1 id="title">{title}</h1>

--- a/webapp/synopsx/templates/html.xhtml
+++ b/webapp/synopsx/templates/html.xhtml
@@ -11,14 +11,21 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="fr" xml:lang="fr">
    <head>
       <meta charset="utf-8"/>
-      <title>Titre du document</title>
+      <title>{title}</title>
       <link href="styles.css" rel="stylesheet"/>
       <script src="scripts.js"></script>
       <!-- ajouter js pour lt IE 9 -->
    </head>
    <header></header>
    <body>
-     <main id="content">
+     <main>
+       <div>
+         <header>
+           <h1>{title}</h1>
+           <h2><span>{quantity}</span> corpus disponibles</h2>
+         </header>
+         {content}
+       </div>
      </main>
    </body>
    <footer></footer>

--- a/webapp/synopsx/templates/tei_chapter.xhtml
+++ b/webapp/synopsx/templates/tei_chapter.xhtml
@@ -2,9 +2,9 @@
 
 <article class="section" xmlns="http://www.w3.org/1999/xhtml">
   <header>
-    <h1 title="title">{title} toto           <span title="date"/></h1>
-    <h2 title="date">{date}</h2>
+    <h1>{title} toto <span title="date"/></h1>
+    <h2>{date}</h2>
   </header>
-  <section title="principal">{principal}</section>
-   <section title="author">{author}</section>
+  <section>{principal}</section>
+   <section>{author}</section>
 </article>

--- a/webapp/synopsx/templates/tei_mentioned_list.xhtml
+++ b/webapp/synopsx/templates/tei_mentioned_list.xhtml
@@ -1,10 +1,8 @@
 <!-- appliquer les standards d'accessibilités ARIA http://www.w3.org/WAI/PF/aria/ -->
 
 
-  <li class="autonym" xmlns="http://www.w3.org/1999/xhtml" title="title">
-  [title]
-    <b title="lang">[lang]</b>
-    <span title="term">[term]</span>
-      <span title="date">[date]</span>
+  <li class="autonym" xmlns="http://www.w3.org/1999/xhtml">{title}<b>{lang}</b>
+    <span>{term}</span>
+      <span>{date}</span>
   </li>
 

--- a/webapp/synopsx/templates/tei_mentioned_table.xhtml
+++ b/webapp/synopsx/templates/tei_mentioned_table.xhtml
@@ -2,7 +2,7 @@
 
 
   <tr class="autonym" xmlns="http://www.w3.org/1999/xhtml">
-    <td id="lang">[lang]</td>
-    <td id="term">[term]</td>
+    <td>{lang}</td>
+    <td>{term}</td>
   </tr>
 

--- a/webapp/synopsx/templates/title_tmpl.xhtml
+++ b/webapp/synopsx/templates/title_tmpl.xhtml
@@ -1,3 +1,3 @@
 <header>
-  <h1>[title]</h1>
+  <h1>{title}</h1>
 </header>


### PR DESCRIPTION
This is a pull request for the blog to facilitate the implementation.

It includes a rewriting of the templating to treat the content between braces in the text nodes and in the attributes. It calls an xslt for the 'tei" content key.

The models exemple give some extent to metadata and a starting library for tei.

@bug the 'order by' clause in the listArticles doesn't work
@todo treat mixed content in the templating
@todo calls xslt fo the content keys starting with "tei:"

Best regards !! -`ღ´-
