### PR TITLE
Small changes

### DIFF
--- a/_restxq/webapp.xqm
+++ b/_restxq/webapp.xqm
@@ -151,7 +151,7 @@ function home($myProject, $myFunction) {
  : @return an html representation of the corpus resource with a bibliographical list
  : the HTML serialization also shows a bibliographical list
  :)
-declare 
+(: declare 
   %restxq:path('/{$myProject}/{$myFunction}/{$myOtherParams = .+}')
   %rest:produces('text/html')
   %output:method("html")
@@ -177,4 +177,4 @@ function home($myProject, $myFunction, $myOtherParams) {
   }catch err:*{   
        synopsx.lib.commons:error($queryParams, $err:code, $err:description)
     }
-};
+}; :)

--- a/lib/commons.xqm
+++ b/lib/commons.xqm
@@ -113,7 +113,7 @@ declare function getFunctionPrefix($queryParams as map(*), $arity as xs:integer)
         else ''
     else ''
     return if ($customizedFunction = '') then                                     
-              if (file:exists(fn:trace($G:MODELS || $fileName))) then 
+              if (file:exists($G:MODELS || $fileName)) then 
                 let $xml := inspect:module($G:MODELS || $fileName)
                 (: if the function exists in this module, returns the module name :)
                 return fn:string($xml/function[@name = fn:string($xml/@prefix) || ':' || $functionName][fn:count(./argument) = $arity]/ancestor::module/@prefix)          


### PR DESCRIPTION
- modify synopsx.models.tei to test the new html wrapping mechanism ; 
- clean fn:trace ; 
- comment default entry-point with %restxq:path('/{$project}/{$page}/{$otherParams = .+}') because it is called in place of customized entry points cf. #54 
