### PR TITLE
New htmlWrapping

### DIFF
--- a/templates/defaultLayout.xhtml
+++ b/templates/defaultLayout.xhtml
@@ -26,6 +26,7 @@
   </nav>
  <main>
     <h1>{title}</h1>
+    <h2>{quantity}</h2>
        <section>{content}</section>
   </main>
 </div> 

--- a/workspace/example/_restxq/example.xqm
+++ b/workspace/example/_restxq/example.xqm
@@ -39,8 +39,39 @@ import module namespace synopsx.mappings.htmlWrapping = 'synopsx.mappings.htmlWr
 declare default function namespace 'example.webapp' ;
 
 
-declare variable $example.webapp:project := 'example';
-declare variable $example.webapp:db := synopsx.lib.commons:getProjectDB($example.webapp:project);
+declare variable $example.webapp:project := 'example' ;
+declare variable $example.webapp:db := synopsx.lib.commons:getProjectDB($example.webapp:project) ;
+
+(:~
+ : resource function to test the new htmlwrapping
+ :
+ : @return a collection of blog's posts
+ :)
+declare 
+  %restxq:path('/test/posts')
+  %rest:produces('text/html')
+  %output:method('html')
+  %output:html-version('5.0')
+function blogPosts() {
+  let $queryParams := map {
+    'project' : $example.webapp:project,
+    'dbName' :  $example.webapp:db,
+    'model' : 'tei' ,
+    'function' : 'getTextsListBis',
+    'sorting' : 'title',
+    'order' : 'ascending'
+    }
+  let $function := synopsx.lib.commons:getModelFunction($queryParams)
+  let $data := fn:function-lookup($function, 1)($queryParams)
+  let $outputParams := map {
+    'lang' : 'fr',
+    'layout' : 'defaultLayout.xhtml',
+    'pattern' : 'inc_defaultList.xhtml'
+    (: specify an xslt mode and other kind of output options :)
+    }
+  return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data, $outputParams)
+  };
+
 (:~
  : this resource function redirect to /home
  :

--- a/workspace/example/templates/inc_defaultList.xhtml
+++ b/workspace/example/templates/inc_defaultList.xhtml
@@ -1,11 +1,16 @@
-<!--
-  TODO : revenir à un système d'attributs @data, par exemple @data-content et @data-attribute pour une écriture plus propre
-  réécrire la fontion synopsx.mappings.htmlWrapping:simplePattern en fonction de ce changement
- -->
-<section>
+<article class="list" xmlns="http://www.w3.org/1999/xhtml">
   <header>
-    <h3 class="type">{title}</h3>
+    <a href="{url}">
+      <h1>{title}</h1>
+      <h2>{subtitle}</h2>
+    </a>
   </header>
-  {content}
-  <hr/>
-</section>
+  <section class="abstract">{abstract}</section>
+  <section class="meta">
+    <ul class="date">{date}</ul>
+    <ul class="author">{author}</ul>
+    <ul class="category">Categorie</ul>
+    <ul class="keywords">mot-clef1, mot-clef2</ul>
+    <ul class="url"><a href="{url}">{url}</a></ul>
+  </section>
+</article>


### PR DESCRIPTION
This pull request contains 
- simplification of the htmlWrapping mechanism wrapperNew(), patternNew()
- sorting the results specifying the content key you wanna sort on with 'sorting'
- defining an order with 'order'
- mixed content in templating (inject rewrited)
- default xquery serialization for TEI
- one example path in workspace/example/ you can check here http://localhost:8984/test/posts/

!! Please take care : the model has changed. The content map is now a sequence of map instead of a map of other maps. This allows sorting with query params before iterating on contents in mappings.

@mingarao @PhilPons I kept the old htmlWrapping function with their name. Please test and, if you agree we could depreciate the old ones.
