### PR TITLE
Dev

### DIFF
--- a/_restxq/synopsx.xqm
+++ b/_restxq/synopsx.xqm
@@ -69,17 +69,3 @@ declare
 function install() { 
   fn:doc($G:TEMPLATES||'defaultLayout.xhtml')
 };
-
-
-
-declare 
-  %restxq:path('/synopsx/inc/header')
-function getHtmlHeader() {
-  fn:doc($G:TEMPLATES||'inc_header.xhtml')
-};
-
-declare 
-  %restxq:path('/synopsx/inc/footer')
-function getHtmlFooter() { 
-  fn:doc($G:TEMPLATES||'inc_footer.xhtml')
-};

--- a/_restxq/webapp.xqm
+++ b/_restxq/webapp.xqm
@@ -157,10 +157,9 @@ function home($myProject, $myFunction) {
 
 declare 
   %restxq:path("/{$myProject}/inc/{$myIncTemplate}")
-function getHtmlHeader($myProject, $myIncTemplate) {
+function getIncTemplate($myProject, $myIncTemplate) {
    let $queryParams := map {
-    'project' :$myProject,
-    'dbName' :synopsx.lib.commons:getProjectDB($myProject)
+    'project' :$myProject
     }
    let $templateName := 'inc_' || $myIncTemplate || '.xhtml'
   return fn:doc(synopsx.lib.commons:getLayoutPath($queryParams, $templateName))

--- a/_restxq/webapp.xqm
+++ b/_restxq/webapp.xqm
@@ -108,14 +108,7 @@ function home($myProject) {
     (: specify an xslt mode and other kind of output options :)
     }
     
-  return try {
-    let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
-    let $data := fn:function-lookup($function, 1)($queryParams)
-    
-    return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data,  $outputParams)
-  }catch err:*{   
-       synopsx.lib.commons:error($queryParams, $err:code, $err:additional)
-    }
+    return synopsx.lib.commons:htmlDisplay($queryParams, $outputParams)
 }; 
 
 (:~
@@ -143,14 +136,7 @@ function home($myProject, $myFunction) {
     (: specify an xslt mode and other kind of output options :)
     }
         
-  return try {
-    let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
-    let $data := fn:function-lookup($function, 1)($queryParams)
-
-    return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data,  $outputParams)
-  }catch err:*{   
-      synopsx.lib.commons:error($queryParams, $err:code, $err:additional)
-    }
+   return synopsx.lib.commons:htmlDisplay($queryParams, $outputParams)
 }; 
 
 

--- a/lib/commons.xqm
+++ b/lib/commons.xqm
@@ -47,7 +47,9 @@ declare function getDefaultProject() as xs:string {
 };
 
 declare function getProjectDB($project as xs:string) as xs:string {
-  fn:doc($G:CONFIGFILE)//config/projects/project[resourceName/text() = $project]/dbName/text()
+  if (fn:doc($G:CONFIGFILE)//config/projects/project[resourceName/text() = $project]/dbName)
+   then fn:doc($G:CONFIGFILE)//config/projects/project[resourceName/text() = $project]/dbName/text()
+  else ''
 };
 
 (:~
@@ -94,6 +96,16 @@ declare function getModelFunction($queryParams as map(*)) as xs:QName {
       else   fn:QName('synopsx.models.mixed', 'notFound') (: give default or error :)
 };
 
+declare function htmlDisplay($queryParams as map(*), $outputParams as map(*)){
+ try {
+    let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
+    let $data := fn:function-lookup($function, 1)($queryParams)
+    
+    return synopsx.mappings.htmlWrapping:wrapper($queryParams, $data,  $outputParams)
+  }catch err:*{   
+       synopsx.lib.commons:error($queryParams, $err:code, $err:additional)
+    }
+};
 
 
 (:~
@@ -117,7 +129,7 @@ declare function error($queryParams, $err:code, $err:additional) {
   let $outputParams := map {
     'lang' : 'fr',
     'layout' : 'error404.xhtml',
-    'pattern' : 'inc_defaultItem.xhtml'
+    'pattern' : 'inc_errorItem.xhtml'
     }
   return synopsx.mappings.htmlWrapping:wrapper($queryParams, $data,  $outputParams)
 };

--- a/templates/defaultLayout.xhtml
+++ b/templates/defaultLayout.xhtml
@@ -26,7 +26,7 @@
   </nav>
  <main>
     <h1>{title}</h1>
-    <h2>{quantity}</h2>
+    <h2>{description}</h2>
        <section>{content}</section>
   </main>
 </div> 

--- a/templates/error404.xhtml
+++ b/templates/error404.xhtml
@@ -21,22 +21,18 @@
  
 <header data-url="/synopsx/inc/header"/>
 <div>
-<hr/>
+<hr/><hr/><hr/><hr/><hr/>
 
   <nav id="contextual" class="sidebar-nav">
       <h3>The SynopsX default contextual nav</h3>
   </nav>
- <main>
+ <article class="type-system-serif">
       <h1>{title}</h1>
       <p>Error code : <span>{error code}</span></p>
       <p>Error stack trace : <span>{error stack trace}</span></p>
-      <p>Requested project : <span>{project}</span></p>
-      <p>Requested database : <span>{dbName}</span></p>
-      <p>Requested model : <span>{model}</span></p>
-      <p>Requested function : <span>{function}</span></p>
-      <p>Other parameters : <span>{otherParams}</span></p>
-    </main>
-
+      
+ </article>
+{content}
   </div> 
 <footer data-url="/synopsx/inc/footer"/>
       <script type="text/javascript">

--- a/templates/home.xhtml
+++ b/templates/home.xhtml
@@ -33,7 +33,7 @@
     
 
   </section>
-     <p>Requested project : <span>{project}</span></p>
+      <p>Requested project : <span>{project}</span></p>
       <p>Requested database : <span>{dbName}</span></p>
       <p>Requested model : <span>{model}</span></p>
       <p>Requested function : <span>{function}</span></p>

--- a/templates/home.xhtml
+++ b/templates/home.xhtml
@@ -17,7 +17,7 @@
    </head>
    <body>
  
-<header data-url="/example/inc/header"/>
+<header data-url="/synopsx/inc/header"/>
 
 <div>
   <nav id="contextual" class="sidebar-nav">
@@ -42,7 +42,7 @@
     
   </div> 
 <hr/>
-<footer data-url="/example/inc/footer"/>
+<footer data-url="/synopsx/inc/footer"/>
      <!-- script menu -->
     <script type="text/javascript">
          // synopsx's composition

--- a/templates/inc_errorItem.xhtml
+++ b/templates/inc_errorItem.xhtml
@@ -1,0 +1,16 @@
+<!-- 
+  TODO : revenir à un système d'attributs @data, par exemple @data-content et @data-attribute pour une écriture plus propre
+  réécrire la fontion synopsx.mappings.htmlWrapping:simplePattern en fonction de ce changement
+ -->
+<article class="type-system-serif">
+  <p>Requested project : <span>{project}</span></p>
+      <p>Requested database : <span>{dbName}</span></p>
+      <p>Requested model : <span>{model}</span></p>
+      <p>Requested function : <span>{function}</span></p>
+      <p>Requested id : <span>{id}</span></p>
+    <!--   Add outputParams -->
+     <!--  <p>Requested layout : <span>{layout}</span></p>
+      <p>Requested pattern : <span>{pattern}</span></p>
+      <p>Requested xslt : <span>{xslt}</span></p>
+      <p>Requested xquery mode : <span>{xquery}</span></p> -->
+</article>

--- a/workspace/example/_restxq/example.xqm
+++ b/workspace/example/_restxq/example.xqm
@@ -42,37 +42,7 @@ declare default function namespace 'example.webapp' ;
 declare variable $example.webapp:project := 'example' ;
 declare variable $example.webapp:db := synopsx.lib.commons:getProjectDB($example.webapp:project) ;
 
-(:~
- : resource function to test the new htmlwrapping
- :
- : @return a collection of blog's posts
- :)
-declare 
-  %restxq:path('/test/posts')
-  %rest:produces('text/html')
-  %output:method('html')
-  %output:html-version('5.0')
-function blogPosts() {
-  let $queryParams := map {
-    'project' : $example.webapp:project,
-    'dbName' :  $example.webapp:db,
-    'model' : 'tei' ,
-    'function' : 'getTextsListBis',
-    'sorting' : 'title',
-    'order' : 'ascending'
-    }
- let $outputParams := map {
-    'lang' : 'fr',
-    'layout' : 'defaultLayout.xhtml',
-    'pattern' : 'inc_defaultList.xhtml'
-    (: specify an xslt mode and other kind of output options :)
-    }
-        
-  let $function := synopsx.lib.commons:getModelFunction($queryParams)
-  let $data := fn:function-lookup($function, 1)($queryParams)
- 
-  return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data, $outputParams)
-  };
+
 
 (:~
  : this resource function redirect to /home
@@ -112,14 +82,7 @@ function home() {
     'pattern' : 'inc_defaultItem.xhtml'
     (: specify an xslt mode and other kind of output options :)
     }  
-  return try {
-    let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
-    let $data := fn:function-lookup($function, 1)($queryParams)
-
-    return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data, $outputParams)
-  }catch err:*{    
-       synopsx.lib.commons:error($queryParams, $err:code, $err:description)
-    }
+ return synopsx.lib.commons:htmlDisplay($queryParams, $outputParams)
 };
 
 (:~
@@ -170,14 +133,7 @@ function textsHtml() {
     'pattern' : 'inc_defaultItem.xhtml'
     (: specify an xslt mode and other kind of output options :)
     }
-  return try {
-    let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
-    let $data := fn:function-lookup($function, 1)($queryParams)
-
-    return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data, $outputParams)
-  }catch err:*{    
-      synopsx.lib.commons:error($queryParams, $err:code, $err:description)
-    }
+ return synopsx.lib.commons:htmlDisplay($queryParams, $outputParams)
 };
 
 declare 
@@ -201,14 +157,7 @@ function respHtml() {
     }
     
     
-  return try {
-    let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
-    let $data := fn:function-lookup($function, 1)($queryParams)
-   
-    return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data, $outputParams)
-  }catch err:*{    
-      synopsx.lib.commons:error($queryParams, $err:code, $err:description)
-    }
+ return synopsx.lib.commons:htmlDisplay($queryParams, $outputParams)
 };
 
 declare 
@@ -232,14 +181,7 @@ function biblHtml() {
     }
     
       
-  return try {
-    let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
-    let $data := fn:function-lookup($function, 1)($queryParams)
-  
-    return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data, $outputParams)
-  }catch err:*{    
-      synopsx.lib.commons:error($queryParams, $err:code, $err:description)
-    }
+ return synopsx.lib.commons:htmlDisplay($queryParams, $outputParams)
 };
 
 (:~
@@ -266,16 +208,7 @@ function corpusListHtml() {
     'pattern' : 'inc_defaultItem.xhtml'
     (: specify an xslt mode and other kind of output options :)
     }
-    
-    
-  return try {
-    let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
-    let $data := fn:function-lookup($function, 1)($queryParams)
-
-    return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data, $outputParams)
-  }catch err:*{    
-      synopsx.lib.commons:error($queryParams, $err:code, $err:description)
-    }
+   return synopsx.lib.commons:htmlDisplay($queryParams, $outputParams)
 };
 
 (:~
@@ -303,13 +236,6 @@ function biblioListHtml($pattern as xs:string?) {
     (: specify an xslt mode and other kind of output options :)
     }
         
-  return try {
-    let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
-    let $data := fn:function-lookup($function, 1)($queryParams)
-  
-    return synopsx.mappings.htmlWrapping:wrapperNew($queryParams, $data, $outputParams)
-  }catch err:*{    
-       synopsx.lib.commons:error($queryParams, $err:code, $err:description)
-    }
+return synopsx.lib.commons:htmlDisplay($queryParams, $outputParams)
 };  
 


### PR DESCRIPTION
Simplify all entry points : the 7 lines of try/catch are factorized in an htmlDisplay function in lib.commons, so only 1 line to write in each entry point instead of 7 !

Rewrite the error function so that it follows the new content structure for html mapping
