### PR TITLE
Finish xslt call mechanism

### DIFF
--- a/_restxq/webapp.xqm
+++ b/_restxq/webapp.xqm
@@ -140,6 +140,36 @@ function home($myProject, $myFunction) {
 }; 
 
 
+(:~
+ : this resource function is the html representation of the corpus resource
+ :
+ : @return an html representation of the corpus resource with a bibliographical list
+ : the HTML serialization also shows a bibliographical list
+ :)
+declare 
+  %restxq:path('/{$myProject}/{$myFunction}/{$value}')
+  %rest:produces('text/html')
+  %output:method("html")
+  %output:html-version("5.0")
+function home($myProject, $myFunction, $value) {
+  let $queryParams := map {
+    'project' : $myProject,
+    'dbName' :  $myProject,
+    'model' : 'tei' ,
+    'function' : $myFunction,
+    'id' : $value
+    }
+    let $outputParams := map {
+    'lang' : 'fr',
+    'layout' : 'home.xhtml',
+    'pattern' : 'inc_defaultItem.xhtml'
+    (: specify an xslt mode and other kind of output options :)
+    }
+        
+   return synopsx.lib.commons:htmlDisplay($queryParams, $outputParams)
+}; 
+
+
 
 (: declare 
   %restxq:path("/{$myProject}/inc/{$myIncTemplate}")

--- a/globals.xqm
+++ b/globals.xqm
@@ -24,6 +24,8 @@ module namespace G = 'synopsx.globals';
  :)
  
 declare variable $G:HOME := file:base-dir() ;
+declare variable $G:WEBAPP := file:parent($G:HOME) ;
+
 declare variable $G:CONFIGFILE := $G:HOME || 'config.xml' ;
 declare variable $G:_RESTXQ := $G:HOME || '_restxq/' ;
 declare variable $G:FILES := $G:HOME || 'files/' ;

--- a/lib/commons.xqm
+++ b/lib/commons.xqm
@@ -74,6 +74,24 @@ declare function getLayoutPath($queryParams as map(*), $template as xs:string?) 
 };
 
 (:~
+ : this function built the layout path based on the project hierarchy
+ :
+ : @param $queryParams the query params
+ : @param $template the template name.extension
+ : @return a path 
+ :)
+declare function getXsltPath($queryParams as map(*), $xsl as xs:string?) as xs:string { 
+  let $path :=  $G:WEBAPP || 'static/' || map:get($queryParams, 'project') || '/xsl/' || $xsl
+  return 
+    if (file:exists($path)) 
+    then $path
+    else if (file:exists($G:FILES || 'xsl/' || $xsl)) then $G:FILES || 'xsl/' || $xsl
+    else $G:FILES || 'xsl/' || 'tei2html.xsl'
+};
+
+ 
+
+(:~
  : this function checks if the function exists in the given module
  :
  : @param module uri and function name
@@ -96,11 +114,11 @@ declare function getModelFunction($queryParams as map(*)) as xs:QName {
       else   fn:QName('synopsx.models.mixed', 'notFound') (: give default or error :)
 };
 
-declare function htmlDisplay($queryParams as map(*), $outputParams as map(*)){
+declare function htmlDisplay($queryParams as map(*), $outputParams as map(*)) as element(*){
  try {
     let $function := xs:QName(synopsx.lib.commons:getModelFunction($queryParams))
     let $data := fn:function-lookup($function, 1)($queryParams)
-    return synopsx.mappings.htmlWrapping:wrapper($queryParams, $data,  $outputParams)
+    return synopsx.mappings.htmlWrapping:wrapper($queryParams, $data, $outputParams)
   }catch err:*{   
        synopsx.lib.commons:error($queryParams, $err:code, $err:additional)
     }

--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -165,5 +165,5 @@ declare function render($outputParams as map(*), $value as node()* ) as element(
     then synopsx.mappings.tei2html:entry($value, $options)
     else if ($xsl) 
       then xslt:transform($value, $G:FILES || 'xsl/' || $xsl)
-      else <p>rien</p>
+      else $value
 };

--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -77,7 +77,7 @@ declare function wrapper($queryParams as map(*), $data as map(*), $outputParams 
           else 
            let $value := map:get($meta, $key)
            return if ($value instance of node()* and $value) 
-           then replace node $text with render($outputParams, $value)
+           then replace node $text with render($queryParams, $outputParams, $value)
            else replace node $text with inject($text, $meta),      
      (: inc :)
      (: todo : call wrapping, rendering and injecting functions for these inc layouts too :)
@@ -102,7 +102,6 @@ declare function pattern($queryParams as map(*), $data as map(*), $outputParams 
     then map:get($queryParams, 'sorting') 
     else ''
   let $order := map:get($queryParams, 'order')
-  let $meta := map:get($data, 'meta')
   let $contents := map:get($data, 'content')
   let $pattern := synopsx.lib.commons:getLayoutPath($queryParams, map:get($outputParams, 'pattern'))
   for $content in $contents
@@ -122,7 +121,7 @@ declare function pattern($queryParams as map(*), $data as map(*), $outputParams 
         let $key := fn:replace($text, '\{|\}', '')
         let $value := map:get($content, $key)
         return if ($value instance of node()* and $value) 
-          then replace node $text with render($outputParams, $value)
+          then replace node $text with render($queryParams, $outputParams, $value)
           else replace node $text with inject($text, $content)
       )
 };
@@ -156,14 +155,14 @@ declare function inject($text as xs:string, $input as map(*)) as xs:string {
  :
  : @todo check the xslt with an xslt 1.0
  :)
-declare function render($outputParams as map(*), $value as node()* ) as element()* {
-  let $xsl :=  map:get($outputParams, 'xsl')
+declare function render($queryParams, $outputParams as map(*), $value as node()* ) as element()* {
   let $xquery := map:get($outputParams, 'xquery')
+  let $xsl :=  map:get($outputParams, 'xsl')
   let $options := 'option'
   return 
     if ($xquery) 
-    then synopsx.mappings.tei2html:entry($value, $options)
+      then synopsx.mappings.tei2html:entry($value, $options)
     else if ($xsl) 
-      then xslt:transform($value, $G:FILES || 'xsl/' || $xsl)
+      then xslt:transform($value, synopsx.lib.commons:getXsltPath($queryParams, $xsl))/*
       else $value
 };

--- a/models/tei.xqm
+++ b/models/tei.xqm
@@ -189,7 +189,7 @@ declare function getHeader($item as element()) {
     'title' : getTitles($item/tei:teiHeader),
     'date' : getDate($item/tei:teiHeader),
     'author' : getAuthors($item/tei:teiHeader),
-    'tei' : getAbstract($item/tei:teiHeader)
+    'description' : getAbstract($item/tei:teiHeader)
   }
 };
 


### PR DESCRIPTION
**CAUTION** : you must add saxon9he to the basex/lib directory to have the synopsx xsl work (XSLT 2.0 instead of 1.0) : http://sourceforge.net/projects/saxon/files/Saxon-HE/9.6/SaxonHE9-6-0-4J.zip/download

This patch :
- Tries to call webapp/static/myProject/xsl/theXslFileName.xsl if exists
- Else tries to call webapp/synopsx/files/xsl/theXslFileName.xsl if exists
- Else calls webapp/synopsx/files/xsl/tei2html.xsl by default 

The xsl must be called in the outputParams map in entry points :
   let $outputParams := map {
    'lang' : 'fr',
    'layout' : 'editions.xhtml',
    'pattern' : 'inc_defaultItem.xhtml',
   'xsl' : 'tei2html.xsl'
    }
