### PR TITLE
templating reload

### DIFF
--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -67,7 +67,7 @@ declare function wrapper($queryParams as map(*), $data as map(*), $outputParams 
   let $regex := '\{(.*?)\}'
   return
     $wrap/* update (
-       (: todo : call wrapping, rendering and injecting functions for these inc layouts too :)
+      (: todo : call wrapping, rendering and injecting functions for these inc layouts too :)
       for $text in .//*[@data-url] 
             let $incOutputParams := map:put($outputParams, 'layout', $text/@data-url || '.xhtml')
             let $inc :=  wrapper($queryParams, $data, $incOutputParams)
@@ -190,3 +190,36 @@ declare function render($queryParams, $outputParams as map(*), $value as node()*
            return xslt:transform($node, synopsx.lib.commons:getXsltPath($queryParams, $xsl))/*
       else $value
 };
+
+(:~
+ : this function dispatch the rendering based on $outpoutParams
+ :
+ :)
+declare function wrapping($queryParams as map(*), $data as map(*), $outputParams as map(*)) as node()* {
+  let $meta := map:get($data, 'meta')
+  let $content := map:get($data, 'content')
+  let $layout := map:get($outputParams, 'layout')
+  let $wrap := fn:doc(synopsx.lib.commons:getLayoutPath($queryParams, $layout))
+  let $regex := '\{.+?\}'
+  return
+    $wrap/* update (
+      for $node in .//@* | .//text()
+      where fn:matches($node, $regex)
+      let $key := fn:replace($node, '\{|\}', '')
+      let $value := map:get($content, $key) 
+      return typeswitch($value)
+          case text() return replace value of node $node with serialize($queryParams, $data, $outputParams, $node)
+          default return ()
+     )
+  };
+
+(:~
+ : this function dispatch the rendering based on $outpoutParams
+ :
+ :) 
+declare function serialize($queryParams as map(*), $data as map(*), $outputParams as map(*), $node) as node()* {
+  let $meta := map:get($data, 'meta')
+  let $content := map:get($data, 'content')
+  let $regex := '\{.+?\}'
+  return ""
+  };

--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -210,7 +210,7 @@ declare function wrapperNew($queryParams as map(*), $data as map(*), $outputPara
   let $regex := '\{(.+?)\}'
   return
     $wrap/* update (
-      for $node in .//*[fn:matches(text(), $regex) or fn:matches(@*, $regex)]
+      for $node in .//*[fn:matches(text(), $regex)]
       let $key := fn:analyze-string($node, $regex)//fn:group/text()
       return if ($key = 'content') 
         then replace node $node with patternNew($queryParams, $data, $outputParams)

--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -187,6 +187,13 @@ declare function render($queryParams, $outputParams as map(*), $value as node()*
       else $value
 };
 
+
+(:~
+ : ~:~:~:~:~:~:~:~:~
+ : templating reloaded
+ : ~:~:~:~:~:~:~:~:~
+ :)
+ 
 (:~
  : this function wrap the content in an HTML layout
  :
@@ -214,12 +221,12 @@ declare function wrapperNew($queryParams as map(*), $data as map(*), $outputPara
   };
 
 (:~
- : this function wrap the content in an HTML layout
+ : this function iterates the pattern template with contents
  :
  : @param $queryParams the query params defined in restxq
- : @param $data the result of the query
+ : @param $data the result of the query to dispacth
  : @param $outputParams the serialization params
- : @return an updated HTML document and instantiate pattern
+ : @return instantiate the pattern with $data
  :
  :)
 declare function patternNew($queryParams as map(*), $data as map(*), $outputParams as map(*)) as node()* {
@@ -249,7 +256,11 @@ declare updating function serialize($queryParams, $data as map(*), $outputParams
   return 
     switch ($value)
       case ($value instance of empty-sequence()) return ()
-      case ($value instance of node()* and fn:not(fn:empty($value))) return replace value of node $text with render($queryParams, $outputParams, $value)
-      default return if ($data instance of empty-sequence()) then () else replace value of node $text with replaceOrLeave($text, $data)
+      case ($value instance of text()) return 
+        replace value of node $text with $value
+      case ($value instance of node()* and fn:not(fn:empty($value))) return 
+        replace value of node $text with render($queryParams, $outputParams, $value)
+      default return 
+        replace value of node $text with replaceOrLeave($text, $data)
   };
  

--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -210,7 +210,7 @@ declare function wrapperNew($queryParams as map(*), $data as map(*), $outputPara
   let $regex := '\{(.+?)\}'
   return
     $wrap/* update (
-      for $node in .//*[fn:matches(text(), $regex)]
+      for $node in .//*[fn:matches(text(), $regex)] | .//@*[fn:matches(., $regex)]
       let $key := fn:analyze-string($node, $regex)//fn:group/text()
       return if ($key = 'content') 
         then replace node $node with patternNew($queryParams, $data, $outputParams)
@@ -235,7 +235,7 @@ declare function patternNew($queryParams as map(*), $data as map(*), $outputPara
   for $content in $contents
   return
     $pattern/* update (
-      for $node in .//*[fn:matches(./text(), $regex) or fn:matches(./@*, $regex) ]
+      for $node in .//*[fn:matches(text(), $regex)] | .//@*[fn:matches(., $regex)]
       return render($queryParams, $content, $outputParams, $node)
       )
   };
@@ -256,5 +256,5 @@ declare updating function render($queryParams, $data as map(*), $outputParams, $
     case xs:integer return replace value of node $node with xs:string($values)
     case element()+ return replace node $node/text() with 
       (for $value in $values return render($queryParams, $outputParams, $value))
-    default return replace value of node $node with render($queryParams, $outputParams, $values)
+    default return replace value of node $node with 'default'
   };

--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -256,11 +256,10 @@ declare updating function serialize($queryParams, $data as map(*), $outputParams
   return 
     switch ($value)
       case ($value instance of empty-sequence()) return ()
-      case ($value instance of text()) return 
+      case ($value instance of xs:string) return 
         replace value of node $text with $value
       case ($value instance of node()* and fn:not(fn:empty($value))) return 
         replace value of node $text with render($queryParams, $outputParams, $value)
       default return 
         replace value of node $text with replaceOrLeave($text, $data)
   };
- 

--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -248,7 +248,7 @@ declare function patternNew($queryParams as map(*), $data as map(*), $outputPara
  : @param $outputParams the serialization params
  : @return an updated node with the data
  :) 
-declare updating function render($queryParams as map(*), $data as map(*), $outputParams as map(*), $node as node()) {
+declare %updating function render($queryParams as map(*), $data as map(*), $outputParams as map(*), $node as node()) {
   let $regex := '\{(.+?)\}'
   let $data := $data
   let $keys := fn:analyze-string($node, $regex)//fn:group/text()

--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -190,7 +190,7 @@ declare function render($queryParams, $outputParams as map(*), $value as node()*
 
 (:~
  : ~:~:~:~:~:~:~:~:~
- : templating reloaded
+ : templating reloaded !
  : ~:~:~:~:~:~:~:~:~
  :)
  
@@ -241,10 +241,14 @@ declare function patternNew($queryParams as map(*), $data as map(*), $outputPara
   };
 
 (:~
- : this function dispatch the rendering based on $outpoutParams
+ : this function dispatch the content with the data
  :
+ : @param $queryParams the query params defined in restxq
+ : @param $data the result of the query to dispacth (meta or content)
+ : @param $outputParams the serialization params
+ : @return an updated node with the data
  :) 
-declare updating function render($queryParams, $data as map(*), $outputParams, $node) {
+declare updating function render($queryParams as map(*), $data as map(*), $outputParams as map(*), $node as node()) {
   let $regex := '\{(.+?)\}'
   let $data := $data
   let $keys := fn:analyze-string($node, $regex)//fn:group/text()
@@ -254,7 +258,12 @@ declare updating function render($queryParams, $data as map(*), $outputParams, $
     case text() return replace value of node $node with $values
     case xs:string return replace value of node $node with $values
     case xs:integer return replace value of node $node with xs:string($values)
-    case element()+ return replace node $node/text() with 
-      (for $value in $values return render($queryParams, $outputParams, $value))
+    case element()+ return replace node $node with 
+      for $value in $values 
+      return element {fn:name($node)} { 
+        for $att in $node/@* return $att, 
+        render($queryParams, $outputParams, $value)
+      }
     default return replace value of node $node with 'default'
   };
+  


### PR DESCRIPTION
This is a proposed new templating mechanism 
- update the element node instead of the text node or attribute node
- render differently according to the type of the map value
- if map value is text() render as xs:string
- if map value is an xs:integer cast to xs:string
- if map value is a sequence copy the node with each value [main goal of the new templating mechanism]

This new templating allows to repeat the element to update, and it allows the use of various types in the data map.

I didn't reproduced yet the injecting functions for inc introduced by @mingarao recently for .//*[@data-url] because exemple is needed.

You can test it with synopsx.mappings.htmlWrapping:wrapperNew(...) instead of synopsx.mappings.htmlWrapping:wrapper(...) in the RESTXQ
